### PR TITLE
去掉搜索结果列表中的推荐搜索词（mode_type in ['rec_query', 'hot_query']）

### DIFF
--- a/media_platform/xhs/core.py
+++ b/media_platform/xhs/core.py
@@ -93,6 +93,7 @@ class XiaoHongShuCrawler(AbstractCrawler):
                 task_list = [
                     self.get_note_detail(post_item.get("id"), semaphore)
                     for post_item in notes_res.get("items", {})
+                    if post_item.get('model_type') not in ('rec_query', 'hot_query')
                 ]
                 note_details = await asyncio.gather(*task_list)
                 for note_detail in note_details:


### PR DESCRIPTION
搜索结果列表中会混入关键词相关和热门词推荐，mode_type为rec_query和hot_query，如果取了这种类型数据的id获取笔记会失败，所以去掉