### PR TITLE
fix: 修复爬取视频/帖子最大数设置值较低导致不爬取的问题

### DIFF
--- a/media_platform/bilibili/core.py
+++ b/media_platform/bilibili/core.py
@@ -93,7 +93,7 @@ class BilibiliCrawler(AbstractCrawler):
         :return:
         """
         utils.logger.info("[BilibiliCrawler.search] Begin search bilibli keywords")
-        bili_limit_count = 20  # bilibili limit page fixed value
+        bili_limit_count = min(20, max(1, config.CRAWLER_MAX_NOTES_COUNT))  # bilibili limit page fixed value
         for keyword in config.KEYWORDS.split(","):
             utils.logger.info(f"[BilibiliCrawler.search] Current search keyword: {keyword}")
             page = 1

--- a/media_platform/douyin/core.py
+++ b/media_platform/douyin/core.py
@@ -84,7 +84,7 @@ class DouYinCrawler(AbstractCrawler):
         for keyword in config.KEYWORDS.split(","):
             utils.logger.info(f"[DouYinCrawler.search] Current keyword: {keyword}")
             aweme_list: List[str] = []
-            dy_limit_count = 10
+            dy_limit_count = min(10, max(1, config.CRAWLER_MAX_NOTES_COUNT))
             page = 0
             while (page + 1) * dy_limit_count <= config.CRAWLER_MAX_NOTES_COUNT:
                 try:

--- a/media_platform/kuaishou/core.py
+++ b/media_platform/kuaishou/core.py
@@ -85,7 +85,7 @@ class KuaishouCrawler(AbstractCrawler):
 
     async def search(self):
         utils.logger.info("[KuaishouCrawler.search] Begin search kuaishou keywords")
-        ks_limit_count = 20  # kuaishou limit page fixed value
+        ks_limit_count = min(20, max(1, config.CRAWLER_MAX_NOTES_COUNT))  # kuaishou limit page fixed value
         for keyword in config.KEYWORDS.split(","):
             utils.logger.info(f"[KuaishouCrawler.search] Current search keyword: {keyword}")
             page = 1

--- a/media_platform/weibo/core.py
+++ b/media_platform/weibo/core.py
@@ -104,7 +104,7 @@ class WeiboCrawler(AbstractCrawler):
         :return:
         """
         utils.logger.info("[WeiboCrawler.search] Begin search weibo keywords")
-        weibo_limit_count = 10
+        weibo_limit_count = min(10, max(1, config.CRAWLER_MAX_NOTES_COUNT))
         for keyword in config.KEYWORDS.split(","):
             utils.logger.info(f"[WeiboCrawler.search] Current search keyword: {keyword}")
             page = 1

--- a/media_platform/xhs/core.py
+++ b/media_platform/xhs/core.py
@@ -96,7 +96,7 @@ class XiaoHongShuCrawler(AbstractCrawler):
     async def search(self) -> None:
         """Search for notes and retrieve their comment information."""
         utils.logger.info("[XiaoHongShuCrawler.search] Begin search xiaohongshu keywords")
-        xhs_limit_count = 20  # xhs limit page fixed value
+        xhs_limit_count = min(20, max(1, config.CRAWLER_MAX_NOTES_COUNT))  # xhs limit page fixed value
         for keyword in config.KEYWORDS.split(","):
             utils.logger.info(f"[XiaoHongShuCrawler.search] Current search keyword: {keyword}")
             page = 1


### PR DESCRIPTION
当 base_config.py 中的 CRAWLER_MAX_NOTES_COUNT 设置值较低时, 比如设置为 5, 爬虫将不会爬取任何数据
```
# 爬取视频/帖子的数量控制
CRAWLER_MAX_NOTES_COUNT = 5
```