### PR TITLE
docs: 恢复文档中误删的字

### DIFF
--- a/docs/常见问题.md
+++ b/docs/常见问题.md
@@ -1,10 +1,10 @@
 ## 常见程序运行出错问题
 
 Q: 爬取抖音报错: `execjs._exceptions.ProgramError: SyntaxError: 缺少 ';'` <br>
-A: 该错误为缺少 nodejs 环境这个错误安装 nodejs 环境即可，版本为：`v16.8.0` <br>
+A: 该错误为缺少 nodejs 环境，这个错误可以通过安装 nodejs 环境来解决，版本为：`v16.8.0` <br>
 
 Q: 可以指定关键词爬取吗？<br>
-A: 在config/base_config.py 中 KEYWORDS 参数用于控制需爬取的关键词 <br>
+A: 在config/base_config.py 中 KEYWORDS 参数用于控制需要爬取的关键词 <br>
 
 Q: 可以指定帖子爬取吗？<br>
 A：在config/base_config.py 中 XHS_SPECIFIED_ID_LIST 参数用于控制需要指定爬取的帖子ID列表 <br>


### PR DESCRIPTION
之前给文档改错别字的时候不小心多删了一个字（在第七行），现在补回来
顺便再改一下上面那句话，这样好像更通顺一点？