### PR TITLE
<bug fix> fetch_creator_notes_detail: id ->note_id

### DIFF
--- a/media_platform/xhs/core.py
+++ b/media_platform/xhs/core.py
@@ -164,7 +164,7 @@ class XiaoHongShuCrawler(AbstractCrawler):
         semaphore = asyncio.Semaphore(config.MAX_CONCURRENCY_NUM)
         task_list = [
             self.get_note_detail(
-                note_id=post_item.get("id"),
+                note_id=post_item.get("note_id"),
                 xsec_source=post_item.get("xsec_source"),
                 xsec_token=post_item.get("xsec_token"),
                 semaphore=semaphore


### PR DESCRIPTION
修复了 `MediaCrawler\media_platform\xhs\core.py` 文件中 `get_note_detail` 方法调用中的属性名称问题。将 note 标识符的属性从 `id` 更改为 `note_id`，以匹配 `post_item` 字典中的正确键。

### 变更内容

- 修改 `MediaCrawler\media_platform\xhs\core.py` 文件中 `get_note_detail` 方法调用的属性名称：
  - **之前：**
    ```python
    self.get_note_detail(
        note_id=post_item.get("id"),
        xsec_source=post_item.get("xsec_source"),
        xsec_token=post_item.get("xsec_token"),
        semaphore=semaphore
    )
    ```
  - **之后：**
    ```python
    self.get_note_detail(
        note_id=post_item.get("note_id"),
        xsec_source=post_item.get("xsec_source"),
        xsec_token=post_item.get("xsec_token"),
        semaphore=semaphore
    )
    ```

### 测试

- [x] 确认 `post_item` 字典包含正确的 `note_id` 键。
- [x] 修改后验证 `get_note_detail` 方法的功能。