### PR TITLE
fix: lost pyexecjs dependecy in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wordcloud==1.9.3
 matplotlib==3.9.0
 requests==2.32.3
 parsel==1.9.1
+pyexecjs==1.5.1


### PR DESCRIPTION
# Issue
zhihu/help.py 中有 import execjs.
但是 execjs 在 requirements.txt 不存在, 还需要手动安装.

# Solution
在 requirements.txt 中增加对应的版本依赖