### PR TITLE
fix:翻页时search id不变

### DIFF
--- a/media_platform/xhs/client.py
+++ b/media_platform/xhs/client.py
@@ -190,6 +190,7 @@ class XiaoHongShuClient(AbstractApiClient):
 
     async def get_note_by_keyword(
             self, keyword: str,
+            search_id: str = get_search_id(),
             page: int = 1, page_size: int = 20,
             sort: SearchSortType = SearchSortType.GENERAL,
             note_type: SearchNoteType = SearchNoteType.ALL
@@ -211,7 +212,7 @@ class XiaoHongShuClient(AbstractApiClient):
             "keyword": keyword,
             "page": page,
             "page_size": page_size,
-            "search_id": get_search_id(),
+            "search_id": search_id,
             "sort": sort.value,
             "note_type": note_type.value
         }

--- a/media_platform/xhs/core.py
+++ b/media_platform/xhs/core.py
@@ -31,7 +31,7 @@ from var import crawler_type_var, source_keyword_var
 from .client import XiaoHongShuClient
 from .exception import DataFetchError
 from .field import SearchSortType
-from .help import parse_note_info_from_note_url
+from .help import parse_note_info_from_note_url, get_search_id
 from .login import XiaoHongShuLogin
 
 
@@ -112,6 +112,7 @@ class XiaoHongShuCrawler(AbstractCrawler):
             source_keyword_var.set(keyword)
             utils.logger.info(f"[XiaoHongShuCrawler.search] Current search keyword: {keyword}")
             page = 1
+            search_id = get_search_id()
             while (page - start_page + 1) * xhs_limit_count <= config.CRAWLER_MAX_NOTES_COUNT:
                 if page < start_page:
                     utils.logger.info(f"[XiaoHongShuCrawler.search] Skip page {page}")
@@ -123,6 +124,7 @@ class XiaoHongShuCrawler(AbstractCrawler):
                     note_id_list: List[str] = []
                     notes_res = await self.xhs_client.get_note_by_keyword(
                         keyword=keyword,
+                        search_id=search_id,
                         page=page,
                         sort=SearchSortType(config.SORT_TYPE) if config.SORT_TYPE != '' else SearchSortType.GENERAL,
                     )


### PR DESCRIPTION
发现并修复一个bug：每次post接口时都会重新生成search id，导致按时间搜索生成的结果会有遗漏或者重复，search id应该是在之前生成，并且page+=1时，search id不变；
