### PR TITLE
添加抖音笔记图片的存储逻辑

### DIFF
--- a/schema/sqlite_tables.sql
+++ b/schema/sqlite_tables.sql
@@ -150,6 +150,7 @@ CREATE TABLE douyin_aweme (
     cover_url TEXT DEFAULT NULL,
     video_download_url TEXT DEFAULT NULL,
     music_download_url TEXT DEFAULT NULL,
+    note_download_url TEXT DEFAULT NULL,
     source_keyword TEXT DEFAULT ''
 );
 

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -150,6 +150,7 @@ CREATE TABLE `douyin_aweme`
     `cover_url`       varchar(500) DEFAULT NULL COMMENT '视频封面图URL',
     `video_download_url`       varchar(1024) DEFAULT NULL COMMENT '视频下载地址',
     `music_download_url`       varchar(1024) DEFAULT NULL COMMENT '音乐下载地址',
+    `note_download_url`        varchar(5120) DEFAULT NULL COMMENT '笔记下载地址',
     PRIMARY KEY (`id`),
     KEY               `idx_douyin_awem_aweme_i_6f7bc6` (`aweme_id`),
     KEY               `idx_douyin_awem_create__299dfe` (`create_time`)


### PR DESCRIPTION
抖音当前除了短视频格式的内容，也支持类似于小红书那样的轮播图片的笔记类型，网页访问的 url 格式为 `https://www.douyin.com/note/抖音内容id`，而短视频的 url 格式为 `https://www.douyin.com/video/抖音内容id`，对于某一个创作者、某一个关键词搜索内容、以及特定的内容id这三种目前支持的爬虫类型而言，可能爬取的内容一部分是短视频，另一部分是笔记。但是无所谓，因为经过测试，在程序使用的三种接口返回的数据中，如果是短视频的话 `images` 参数为 `null`，而笔记的话 `images` 参数为包含字典的列表，例如以下格式：
```json
"images": [
        {
            "download_url_list": [
                "https://p3-pc-sign.douyinpic.com/tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C~tplv-dy-water-v2:5oqW6Z-z5Y-377yaRGVvY2lu:1024:1024.webp?lk3s=138a59ce&x-expires=1756382400&x-signature=9xOxW1RaKYO%2ByWSD7MCKHEm%2BYG4%3D&sig=kblyZILo7u37tbbySt8GRVYoB2E%3D&from=327834062&s=PackSourceEnum_AWEME_DETAIL&se=false&sc=image&biz_tag=aweme_images&l=202507292023412D8E365EA7F8F7446B55",
                "https://p9-pc-sign.douyinpic.com/tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C~tplv-dy-water-v2:5oqW6Z-z5Y-377yaRGVvY2lu:1024:1024.webp?lk3s=138a59ce&x-expires=1756382400&x-signature=WcvUawNI0yIQEhgmeWl9EHrkEYc%3D&sig=kblyZILo7u37tbbySt8GRVYoB2E%3D&from=327834062&s=PackSourceEnum_AWEME_DETAIL&se=false&sc=image&biz_tag=aweme_images&l=202507292023412D8E365EA7F8F7446B55",
                "https://p3-pc-sign.douyinpic.com/tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C~tplv-dy-water-v2:5oqW6Z-z5Y-377yaRGVvY2lu:1024:1024.jpeg?lk3s=138a59ce&x-expires=1756382400&x-signature=L0cSbW4DKaflIYdLcckmlBisCWY%3D&sig=pBDBOxxg-qETc8IiCSTwSXessO4%3D&from=327834062&s=PackSourceEnum_AWEME_DETAIL&se=false&sc=image&biz_tag=aweme_images&l=202507292023412D8E365EA7F8F7446B55"
            ],
            "height": 1024,
            "is_new_text_mode": 0,
            "uri": "tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C",
            "url_list": [
                "https://p3-pc-sign.douyinpic.com/tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C~tplv-dy-aweme-images:q75.webp?lk3s=138a59ce&x-expires=1756382400&x-signature=mXWJZ%2BRO7ny15JaY%2BdVduEH%2Bwv0%3D&from=327834062&s=PackSourceEnum_AWEME_DETAIL&se=false&sc=image&biz_tag=aweme_images&l=202507292023412D8E365EA7F8F7446B55",
                "https://p9-pc-sign.douyinpic.com/tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C~tplv-dy-aweme-images:q75.webp?lk3s=138a59ce&x-expires=1756382400&x-signature=gAGThWJdyB96wXZ5hj%2FMpdkAD5o%3D&from=327834062&s=PackSourceEnum_AWEME_DETAIL&se=false&sc=image&biz_tag=aweme_images&l=202507292023412D8E365EA7F8F7446B55",
                "https://p3-pc-sign.douyinpic.com/tos-cn-i-0813c001/oUEAICPf5lsEg3A9YldovAFZpAxDBBgAAfmh3C~tplv-dy-aweme-images:q75.jpeg?lk3s=138a59ce&x-expires=1756382400&x-signature=FkXk3aDAu7X8KuS3n2%2BS8%2Fipr0U%3D&from=327834062&s=PackSourceEnum_AWEME_DETAIL&se=false&sc=image&biz_tag=aweme_images&l=202507292023412D8E365EA7F8F7446B55"
            ],
            "width": 1024
        },
        ......省略余下的笔记图片内容
]
```
其中 `download_url_list` 为带水印的图片，`url_list` 为不带水印的图片，列表中前n-1为webp格式的图片，最后一个为jpeg的图片。
所以本次提交**仅修改有关提取内容部分的代码**，使其支持 `note_download_url` 字段，表示笔记中多张图片的下载地址，存储为字符串类型并用 `,` 分割不同图片 `url`。

---

由于本次提交仅修改了正文内容部分的提取，所以仅附上与其对应的 contents 文件，测试结果文件如下：
- search 模式，搜索关键字为 `希露非叶特`，搜索到的混杂视频与笔记的正文内容文件如下：
[search_contents_2025-07-30.json](https://github.com/user-attachments/files/21500374/search_contents_2025-07-30.json)
- detail 模式，搜索内容id为 `7527650609337437467`（此id为一个笔记，若需视频与笔记混杂的正文内容请查看 search 与 creator 模式的输出结果），搜索到的正文内容文件如下：
[detail_contents_2025-07-30.json](https://github.com/user-attachments/files/21500402/detail_contents_2025-07-30.json)
- creator 模式，搜索用户id为 `MS4wLjABAAAA8JKCtDHC939hOsgQ1dmUbFblzKwU8BWAsBVIP4ZgNO4`，搜索到的混杂视频与笔记的正文内容文件如下：
[creator_contents_2025-07-30.json](https://github.com/user-attachments/files/21500425/creator_contents_2025-07-30.json)