### PR TITLE
fix: #685

### DIFF
--- a/tools/crawler_util.py
+++ b/tools/crawler_util.py
@@ -24,7 +24,7 @@ from io import BytesIO
 from typing import Dict, List, Optional, Tuple, cast
 
 import httpx
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageShow
 from playwright.async_api import Cookie, Page
 
 from . import utils
@@ -88,6 +88,7 @@ def show_qrcode(qr_code) -> None:  # type: ignore
     new_image.paste(image, (10, 10))
     draw = ImageDraw.Draw(new_image)
     draw.rectangle((0, 0, width + 19, height + 19), outline=(0, 0, 0), width=1)
+    del ImageShow.UnixViewer.options["save_all"]
     new_image.show()
 
 


### PR DESCRIPTION
Pillow 会把图片保存为临时文件并调用系统默认查看器（比如 Gwenview）打开，但保存的格式是 APNG，而 Gwenview 不支持 APNG。

在调用 show() 前删除 save_all 选项，这样 Pillow 就不会保存为 APNG：

```python
from PIL import Image, ImageShow

# 删除 save_all 选项，避免保存为 APNG
del ImageShow.UnixViewer.options["save_all"]
img = Image.open("your_image.png")
img.show()
```