### PR TITLE
fix: 修复zhihu评论爬取分页问题

### DIFF
--- a/media_platform/zhihu/client.py
+++ b/media_platform/zhihu/client.py
@@ -299,8 +299,10 @@ class ZhiHuClient(AbstractApiClient, ProxyRefreshMixin):
         result: List[ZhihuComment] = []
         is_end: bool = False
         offset: str = ""
+        prev_offset: str = ""
         limit: int = 10
         while not is_end:
+            prev_offset = offset
             root_comment_res = await self.get_root_comments(content.content_id, content.content_type, offset, limit)
             if not root_comment_res:
                 break
@@ -310,6 +312,9 @@ class ZhiHuClient(AbstractApiClient, ProxyRefreshMixin):
             comments = self._extractor.extract_comments(content, root_comment_res.get("data"))
 
             if not comments:
+                break
+
+            if prev_offset == offset:
                 break
 
             if callback:
@@ -348,8 +353,10 @@ class ZhiHuClient(AbstractApiClient, ProxyRefreshMixin):
 
             is_end: bool = False
             offset: str = ""
+            prev_offset: str = ""
             limit: int = 10
             while not is_end:
+                prev_offset = offset
                 child_comment_res = await self.get_child_comments(parment_comment.comment_id, offset, limit)
                 if not child_comment_res:
                     break
@@ -359,6 +366,9 @@ class ZhiHuClient(AbstractApiClient, ProxyRefreshMixin):
                 sub_comments = self._extractor.extract_comments(content, child_comment_res.get("data"))
 
                 if not sub_comments:
+                    break
+
+                if prev_offset == offset:
                     break
 
                 if callback:


### PR DESCRIPTION
在使用 zhihu 爬虫爬取回复时，爬虫可能进入死循环，持续请求相同的最后一页，无法正常退出

## 原因分析
相关 API 的响应 json 中，通常通过 paging.is_end 标识是否还有更多数据。但在某些情况下（可能是 API 的 bug），即使已到达最后一页，is_end 依然为 false，并且 paging.next 指向当前页，导致爬虫的 while 循环无法终止，不断重复请求同一页。相关示例见测试用例

## 解决方案
在分页循环中加入对 offset 的检查。记录上一次请求的 offset 值，如果当前请求的 offset 与上一次相同，则说明没有新数据被返回，并跳出循环

## 测试用例
1. 修改 zhihu_config.py 中的配置爬取测试文章
2. 测试文章 URL：https://zhuanlan.zhihu.com/p/1970580023086920612
3. 运行命令：uv run main.py --platform zhihu --lt qrcode --type detail --get_sub_comment y（或根据实际命令调整）

修复前：offset=5_11357655844_0 时陷入死循环
修复后：检测到 offset 重复后跳出循环
