### PR TITLE
Handle error for keyword search

### DIFF
--- a/media_platform/weibo/core.py
+++ b/media_platform/weibo/core.py
@@ -167,7 +167,13 @@ class WeiboCrawler(AbstractCrawler):
                     page += 1
                     continue
                 utils.logger.info(f"[WeiboCrawler.search] search weibo keyword: {keyword}, page: {page}")
-                search_res = await self.wb_client.get_note_by_keyword(keyword=keyword, page=page, search_type=search_type)
+                try:
+                    search_res = await self.wb_client.get_note_by_keyword(keyword=keyword, page=page, search_type=search_type)
+                except Exception as ex:
+                    utils.logger.error(f"[WeiboCrawler.search] Error fetching keyword {keyword} at page {page}: {ex}")
+                    utils.logger.info(f"[WeiboCrawler.search] Moving to the next keyword.")
+                    break
+
                 note_id_list: List[str] = []
                 note_list = filter_search_result_card(search_res.get("cards"))
                 # If full text fetching is enabled, batch get full text of posts


### PR DESCRIPTION
WeiboCrawler.search raises `tenacity.RetryError` / `DataFetchError` when it goes too deep and runs out of notes (weibo API returns `res:{'ok': 0, 'msg': '这里还没有内容', 'data': {'cards': []}}`), which breaks the program. This becomes a headache when the user specified a long list of keywords and expected the crawler to finish searching as much as possible for all of them.

Add error handling for keyword search in WeiboCrawler so it moves on to the next keyword when it runs out of notes instead of crashing the whole program.