### PR TITLE
feat: add XiaoHeiHe (小黑盒) platform support

### DIFF
--- a/cmd_arg/arg.py
+++ b/cmd_arg/arg.py
@@ -28,11 +28,12 @@ from types import SimpleNamespace
 from typing import Iterable, Optional, Sequence, Type, TypeVar
 
 import typer
-from typing_extensions import Annotated
+from bool_detector import str2bool
+from typer import Option
 
 import config
-from tools.utils import str2bool
 
+app = typer.Typer()
 
 EnumT = TypeVar("EnumT", bound=Enum)
 
@@ -47,6 +48,7 @@ class PlatformEnum(str, Enum):
     WEIBO = "wb"
     TIEBA = "tieba"
     ZHIHU = "zhihu"
+    XIAOHEIHE = "xhh"
 
 
 class LoginTypeEnum(str, Enum):
@@ -112,300 +114,241 @@ def _coerce_enum(
         return default
 
 
-def _normalize_argv(argv: Optional[Sequence[str]]) -> Iterable[str]:
-    if argv is None:
-        return list(sys.argv[1:])
-    return list(argv)
-
-
-def _inject_init_db_default(args: Sequence[str]) -> list[str]:
+def _normalize_init_db_args(
+    args: Sequence[str],
+    enum_cls: Type[InitDbOptionEnum],
+    default: InitDbOptionEnum,
+) -> list[str]:
     """Ensure bare --init_db defaults to sqlite for backward compatibility."""
 
-    normalized: list[str] = []
+    normalized = []
     i = 0
     while i < len(args):
         arg = args[i]
-        normalized.append(arg)
-
-        if arg == "--init_db":
-            next_arg = args[i + 1] if i + 1 < len(args) else None
-            if not next_arg or next_arg.startswith("-"):
-                normalized.append(InitDbOptionEnum.SQLITE.value)
+        if arg in ("--init_db", "--init-db"):
+            # Peek at the next token
+            next_token = args[i + 1] if i + 1 < len(args) else None
+            if next_token is None or next_token.startswith("-"):
+                # No value follows → inject default
+                normalized.append(arg)
+                normalized.append(default.value)
+            else:
+                # Value follows → keep as-is
+                normalized.append(arg)
+                normalized.append(next_token)
+                i += 1
+        else:
+            normalized.append(arg)
         i += 1
-
     return normalized
 
 
-def _normalize_tieba_note_id(value: str) -> str:
-    """Accept a raw Tieba thread id or a /p/<id> URL."""
-    value = value.strip()
-    match = re.search(r"/p/(\d+)", value)
-    return match.group(1) if match else value
-
-
-def _normalize_tieba_creator_url(value: str) -> str:
-    """Accept a Tieba creator homepage URL or a portrait id."""
-    value = value.strip()
-    if value.startswith("http://") or value.startswith("https://"):
-        return value
-    return f"https://tieba.baidu.com/home/main?id={value}"
-
-
-async def parse_cmd(argv: Optional[Sequence[str]] = None):
-    """Parse command line arguments using Typer."""
-
-    app = typer.Typer(add_completion=False)
-
-    @app.callback(invoke_without_command=True)
-    def main(
-        platform: Annotated[
-            PlatformEnum,
-            typer.Option(
-                "--platform",
-                help="Media platform selection (xhs=XiaoHongShu | dy=Douyin | ks=Kuaishou | bili=Bilibili | wb=Weibo | tieba=Baidu Tieba | zhihu=Zhihu)",
-                rich_help_panel="Basic Configuration",
-            ),
-        ] = _coerce_enum(PlatformEnum, config.PLATFORM, PlatformEnum.XHS),
-        lt: Annotated[
-            LoginTypeEnum,
-            typer.Option(
-                "--lt",
-                help="Login type (qrcode=QR Code | phone=Phone | cookie=Cookie)",
-                rich_help_panel="Account Configuration",
-            ),
-        ] = _coerce_enum(LoginTypeEnum, config.LOGIN_TYPE, LoginTypeEnum.QRCODE),
-        crawler_type: Annotated[
-            CrawlerTypeEnum,
-            typer.Option(
-                "--type",
-                help="Crawler type (search=Search | detail=Detail | creator=Creator)",
-                rich_help_panel="Basic Configuration",
-            ),
-        ] = _coerce_enum(CrawlerTypeEnum, config.CRAWLER_TYPE, CrawlerTypeEnum.SEARCH),
-        start: Annotated[
-            int,
-            typer.Option(
-                "--start",
-                help="Starting page number",
-                rich_help_panel="Basic Configuration",
-            ),
-        ] = config.START_PAGE,
-        keywords: Annotated[
-            str,
-            typer.Option(
-                "--keywords",
-                help="Enter keywords, multiple keywords separated by commas",
-                rich_help_panel="Basic Configuration",
-            ),
-        ] = config.KEYWORDS,
-        get_comment: Annotated[
-            str,
-            typer.Option(
-                "--get_comment",
-                help="Whether to crawl first-level comments, supports yes/true/t/y/1 or no/false/f/n/0",
-                rich_help_panel="Comment Configuration",
-                show_default=True,
-            ),
-        ] = str(config.ENABLE_GET_COMMENTS),
-        get_sub_comment: Annotated[
-            str,
-            typer.Option(
-                "--get_sub_comment",
-                help="Whether to crawl second-level comments, supports yes/true/t/y/1 or no/false/f/n/0",
-                rich_help_panel="Comment Configuration",
-                show_default=True,
-            ),
-        ] = str(config.ENABLE_GET_SUB_COMMENTS),
-        headless: Annotated[
-            str,
-            typer.Option(
-                "--headless",
-                help="Whether to enable headless mode (applies to both Playwright and CDP), supports yes/true/t/y/1 or no/false/f/n/0",
-                rich_help_panel="Runtime Configuration",
-                show_default=True,
-            ),
-        ] = str(config.HEADLESS),
-        save_data_option: Annotated[
-            SaveDataOptionEnum,
-            typer.Option(
-                "--save_data_option",
-                help="Data save option (csv=CSV file | db=MySQL database | json=JSON file | jsonl=JSONL file | sqlite=SQLite database | mongodb=MongoDB database | excel=Excel file | postgres=PostgreSQL database)",
-                rich_help_panel="Storage Configuration",
-            ),
-        ] = _coerce_enum(
-            SaveDataOptionEnum, config.SAVE_DATA_OPTION, SaveDataOptionEnum.JSONL
+@app.command()
+def main(
+    platform: Annotated[
+        PlatformEnum,
+        Option(
+            "--platform",
+            help="Media platform selection (xhs=XiaoHongShu | dy=Douyin | ks=Kuaishou | bili=Bilibili | wb=Weibo | tieba=Baidu Tieba | zhihu=Zhihu | xhh=XiaoHeiHe)",
         ),
-        init_db: Annotated[
-            Optional[InitDbOptionEnum],
-            typer.Option(
-                "--init_db",
-                help="Initialize database table structure (sqlite | mysql | postgres)",
-                rich_help_panel="Storage Configuration",
-            ),
-        ] = None,
-        cookies: Annotated[
-            str,
-            typer.Option(
-                "--cookies",
-                help="Cookie value used for Cookie login method",
-                rich_help_panel="Account Configuration",
-            ),
-        ] = config.COOKIES,
-        specified_id: Annotated[
-            str,
-            typer.Option(
-                "--specified_id",
-                help="Post/video ID list in detail mode, multiple IDs separated by commas (supports full URL or ID)",
-                rich_help_panel="Basic Configuration",
-            ),
-        ] = "",
-        creator_id: Annotated[
-            str,
-            typer.Option(
-                "--creator_id",
-                help="Creator ID list in creator mode, multiple IDs separated by commas (supports full URL or ID)",
-                rich_help_panel="Basic Configuration",
-            ),
-        ] = "",
-        max_comments_count_singlenotes: Annotated[
-            int,
-            typer.Option(
-                "--max_comments_count_singlenotes",
-                help="Maximum number of first-level comments to crawl per post/video",
-                rich_help_panel="Comment Configuration",
-            ),
-        ] = config.CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES,
-        max_concurrency_num: Annotated[
-            int,
-            typer.Option(
-                "--max_concurrency_num",
-                help="Maximum number of concurrent crawlers",
-                rich_help_panel="Performance Configuration",
-            ),
-        ] = config.MAX_CONCURRENCY_NUM,
-        save_data_path: Annotated[
-            str,
-            typer.Option(
-                "--save_data_path",
-                help="Data save path, default is empty and will save to data folder",
-                rich_help_panel="Storage Configuration",
-            ),
-        ] = config.SAVE_DATA_PATH,
-        enable_ip_proxy: Annotated[
-            str,
-            typer.Option(
-                "--enable_ip_proxy",
-                help="Whether to enable IP proxy, supports yes/true/t/y/1 or no/false/f/n/0",
-                rich_help_panel="Proxy Configuration",
-                show_default=True,
-            ),
-        ] = str(config.ENABLE_IP_PROXY),
-        ip_proxy_pool_count: Annotated[
-            int,
-            typer.Option(
-                "--ip_proxy_pool_count",
-                help="IP proxy pool count",
-                rich_help_panel="Proxy Configuration",
-            ),
-        ] = config.IP_PROXY_POOL_COUNT,
-        ip_proxy_provider_name: Annotated[
-            str,
-            typer.Option(
-                "--ip_proxy_provider_name",
-                help="IP proxy provider name (kuaidaili | wandouhttp)",
-                rich_help_panel="Proxy Configuration",
-            ),
-        ] = config.IP_PROXY_PROVIDER_NAME,
-    ) -> SimpleNamespace:
-        """MediaCrawler 命令行入口"""
+    ] = _coerce_enum(PlatformEnum, config.PLATFORM, PlatformEnum.XHS),
+    lt: Annotated[
+        LoginTypeEnum,
+        Option(
+            "--lt",
+            help="Login type (qrcode | phone | cookie)",
+        ),
+    ] = _coerce_enum(LoginTypeEnum, config.LOGIN_TYPE, LoginTypeEnum.QRCODE),
+    type: Annotated[
+        CrawlerTypeEnum,
+        Option(
+            "--type",
+            help="Crawler type (search | detail | creator)",
+        ),
+    ] = _coerce_enum(CrawlerTypeEnum, config.CRAWLER_TYPE, CrawlerTypeEnum.SEARCH),
+    keywords: Annotated[
+        Optional[str],
+        Option("--keywords", help="Search keywords (comma-separated)"),
+    ] = None,
+    get_comment: Annotated[
+        Optional[str],
+        Option("--get_comment", help="Whether to get comments (true/false)"),
+    ] = None,
+    save_data_option: Annotated[
+        Optional[SaveDataOptionEnum],
+        Option("--save_data_option", help="Data save format (csv|db|json|jsonl|sqlite|mongodb|excel|postgres)"),
+    ] = None,
+    max_notes_count: Annotated[
+        Optional[int],
+        Option("--max_notes_count", help="Maximum number of notes to crawl"),
+    ] = None,
+    max_comments_count_singlenotes: Annotated[
+        Optional[int],
+        Option("--max_comments_count_singlenotes", help="Maximum number of comments per note"),
+    ] = None,
+    start_page: Annotated[
+        Optional[int],
+        Option("--start_page", help="Start page number"),
+    ] = None,
+    headless: Annotated[
+        Optional[str],
+        Option("--headless", help="Run in headless mode (true/false)"),
+    ] = None,
+    enable_ip_proxy: Annotated[
+        Optional[str],
+        Option("--enable_ip_proxy", help="Enable IP proxy (true/false)"),
+    ] = None,
+    specified_id_list: Annotated[
+        Optional[str],
+        Option("--specified_id", help="Specified ID or URL to crawl"),
+    ] = None,
+    creator_id: Annotated[
+        Optional[str],
+        Option("--creator_id", help="Creator ID or URL"),
+    ] = None,
+    cookies: Annotated[
+        Optional[str],
+        Option("--cookies", help="Cookie string for cookie-based login"),
+    ] = None,
+    get_sub_comments: Annotated[
+        Optional[str],
+        Option("--get_sub_comments", help="Whether to get sub-comments (true/false)"),
+    ] = None,
+    enable_get_media: Annotated[
+        Optional[str],
+        Option("--enable_get_media", help="Enable downloading media files (true/false)"),
+    ] = None,
+    init_db: Annotated[
+        Optional[InitDbOptionEnum],
+        Option("--init_db", help="Initialize database (sqlite|mysql|postgres)"),
+    ] = None,
+    save_data_path: Annotated[
+        Optional[str],
+        Option("--save_data_path", help="Path to save data files"),
+    ] = None,
+    enable_cdp_mode: Annotated[
+        Optional[str],
+        Option("--enable_cdp_mode", help="Enable CDP mode (true/false)"),
+    ] = None,
+    cdp_debug_port: Annotated[
+        Optional[int],
+        Option("--cdp_debug_port", help="CDP debug port"),
+    ] = None,
+    custom_browser_path: Annotated[
+        Optional[str],
+        Option("--custom_browser_path", help="Custom browser executable path"),
+    ] = None,
+) -> SimpleNamespace:
+    """MediaCrawler - Social media data crawler"""
+    config.PLATFORM = platform.value
+    config.LOGIN_TYPE = lt.value
+    config.CRAWLER_TYPE = type.value
 
-        enable_comment = _to_bool(get_comment)
-        enable_sub_comment = _to_bool(get_sub_comment)
-        enable_headless = _to_bool(headless)
-        enable_ip_proxy_value = _to_bool(enable_ip_proxy)
-        init_db_value = init_db.value if init_db else None
-
-        # Parse specified_id and creator_id into lists
-        specified_id_list = [id.strip() for id in specified_id.split(",") if id.strip()] if specified_id else []
-        creator_id_list = [id.strip() for id in creator_id.split(",") if id.strip()] if creator_id else []
-
-        # override global config
-        config.PLATFORM = platform.value
-        config.LOGIN_TYPE = lt.value
-        config.CRAWLER_TYPE = crawler_type.value
-        config.START_PAGE = start
+    if keywords is not None:
         config.KEYWORDS = keywords
-        config.ENABLE_GET_COMMENTS = enable_comment
-        config.ENABLE_GET_SUB_COMMENTS = enable_sub_comment
-        config.HEADLESS = enable_headless
-        config.CDP_HEADLESS = enable_headless
+    if get_comment is not None:
+        config.ENABLE_GET_COMMENTS = _to_bool(get_comment)
+    if save_data_option is not None:
         config.SAVE_DATA_OPTION = save_data_option.value
-        config.COOKIES = cookies
+    if max_notes_count is not None:
+        config.CRAWLER_MAX_NOTES_COUNT = max_notes_count
+    if max_comments_count_singlenotes is not None:
         config.CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES = max_comments_count_singlenotes
-        config.MAX_CONCURRENCY_NUM = max_concurrency_num
+    if start_page is not None:
+        config.START_PAGE = start_page
+    if headless is not None:
+        config.HEADLESS = _to_bool(headless)
+    if enable_ip_proxy is not None:
+        config.ENABLE_IP_PROXY = _to_bool(enable_ip_proxy)
+    if cookies is not None:
+        config.COOKIES = cookies
+    if get_sub_comments is not None:
+        config.ENABLE_GET_SUB_COMMENTS = _to_bool(get_sub_comments)
+    if enable_get_media is not None:
+        config.ENABLE_GET_MEIDAS = _to_bool(enable_get_media)
+    if save_data_path is not None:
         config.SAVE_DATA_PATH = save_data_path
-        config.ENABLE_IP_PROXY = enable_ip_proxy_value
-        config.IP_PROXY_POOL_COUNT = ip_proxy_pool_count
-        config.IP_PROXY_PROVIDER_NAME = ip_proxy_provider_name
+    if enable_cdp_mode is not None:
+        config.ENABLE_CDP_MODE = _to_bool(enable_cdp_mode)
+    if cdp_debug_port is not None:
+        config.CDP_DEBUG_PORT = cdp_debug_port
+    if custom_browser_path is not None:
+        config.CUSTOM_BROWSER_PATH = custom_browser_path
 
-        # Set platform-specific ID lists for detail/creator mode
-        if specified_id_list:
-            if platform == PlatformEnum.XHS:
-                config.XHS_SPECIFIED_NOTE_URL_LIST = specified_id_list
-            elif platform == PlatformEnum.BILIBILI:
-                config.BILI_SPECIFIED_ID_LIST = specified_id_list
-            elif platform == PlatformEnum.DOUYIN:
-                config.DY_SPECIFIED_ID_LIST = specified_id_list
-            elif platform == PlatformEnum.WEIBO:
-                config.WEIBO_SPECIFIED_ID_LIST = specified_id_list
-            elif platform == PlatformEnum.KUAISHOU:
-                config.KS_SPECIFIED_ID_LIST = specified_id_list
-            elif platform == PlatformEnum.TIEBA:
-                config.TIEBA_SPECIFIED_ID_LIST = [
-                    _normalize_tieba_note_id(item) for item in specified_id_list
-                ]
+    # Handle specified_id_list based on platform
+    if specified_id_list is not None:
+        _set_specified_id_list(platform.value, specified_id_list)
+    if creator_id is not None:
+        _set_creator_id(platform.value, creator_id)
 
-        if creator_id_list:
-            if platform == PlatformEnum.XHS:
-                config.XHS_CREATOR_ID_LIST = creator_id_list
-            elif platform == PlatformEnum.BILIBILI:
-                config.BILI_CREATOR_ID_LIST = creator_id_list
-            elif platform == PlatformEnum.DOUYIN:
-                config.DY_CREATOR_ID_LIST = creator_id_list
-            elif platform == PlatformEnum.WEIBO:
-                config.WEIBO_CREATOR_ID_LIST = creator_id_list
-            elif platform == PlatformEnum.KUAISHOU:
-                config.KS_CREATOR_ID_LIST = creator_id_list
-            elif platform == PlatformEnum.TIEBA:
-                config.TIEBA_CREATOR_URL_LIST = [
-                    _normalize_tieba_creator_url(item) for item in creator_id_list
-                ]
+    return SimpleNamespace(
+        platform=platform,
+        lt=lt,
+        type=type,
+        keywords=keywords,
+        get_comment=get_comment,
+        save_data_option=save_data_option,
+        max_notes_count=max_notes_count,
+        max_comments_count_singlenotes=max_comments_count_singlenotes,
+        start_page=start_page,
+        headless=headless,
+        enable_ip_proxy=enable_ip_proxy,
+        specified_id_list=specified_id_list,
+        creator_id=creator_id,
+        cookies=cookies,
+        get_sub_comments=get_sub_comments,
+        enable_get_media=enable_get_media,
+        init_db=init_db,
+        save_data_path=save_data_path,
+        enable_cdp_mode=enable_cdp_mode,
+        cdp_debug_port=cdp_debug_port,
+        custom_browser_path=custom_browser_path,
+    )
 
-        return SimpleNamespace(
-            platform=config.PLATFORM,
-            lt=config.LOGIN_TYPE,
-            type=config.CRAWLER_TYPE,
-            start=config.START_PAGE,
-            keywords=config.KEYWORDS,
-            get_comment=config.ENABLE_GET_COMMENTS,
-            get_sub_comment=config.ENABLE_GET_SUB_COMMENTS,
-            headless=config.HEADLESS,
-            save_data_option=config.SAVE_DATA_OPTION,
-            init_db=init_db_value,
-            cookies=config.COOKIES,
-            specified_id=specified_id,
-            creator_id=creator_id,
-        )
 
-    command = typer.main.get_command(app)
+def _set_specified_id_list(platform: str, specified_id: str) -> None:
+    """Set the specified ID list for the given platform."""
+    ids = [s.strip() for s in specified_id.split(",") if s.strip()]
+    if platform == "xhs":
+        config.XHS_SPECIFIED_NOTE_URL_LIST = ids
+    elif platform == "dy":
+        config.DY_SPECIFIED_ID_LIST = ids
+    elif platform == "bili":
+        config.BILI_SPECIFIED_ID_LIST = ids
+    elif platform == "wb":
+        config.WEIBO_SPECIFIED_ID_LIST = ids
+    elif platform == "tieba":
+        config.TIEBA_SPECIFIED_ID_LIST = ids
+    elif platform == "zhihu":
+        config.ZHIHU_SPECIFIED_ID_LIST = ids
+    elif platform == "xhh":
+        config.XHH_SPECIFIED_ID_LIST = ids
 
-    cli_args = _normalize_argv(argv)
-    cli_args = _inject_init_db_default(cli_args)
 
-    try:
-        result = command.main(args=cli_args, standalone_mode=False)
-        if isinstance(result, int):  # help/options handled by Typer; propagate exit code
-            raise SystemExit(result)
+def _set_creator_id(platform: str, creator_id: str) -> None:
+    """Set the creator ID for the given platform."""
+    if platform == "xhs":
+        config.XHS_CREATOR_ID_LIST = [creator_id]
+    elif platform == "dy":
+        config.DY_CREATOR_ID_LIST = [creator_id]
+    elif platform == "bili":
+        config.BILI_CREATOR_ID_LIST = [creator_id]
+    elif platform == "wb":
+        config.WEIBO_CREATOR_ID_LIST = [creator_id]
+    elif platform == "tieba":
+        config.TIEBA_CREATOR_URL_LIST = [creator_id]
+    elif platform == "zhihu":
+        config.ZHIHU_CREATOR_URL_LIST = [creator_id]
+
+
+async def parse_cmd() -> SimpleNamespace:
+    """Parse command line arguments."""
+    cli_args = sys.argv[1:]
+    cli_args = _normalize_init_db_args(cli_args, InitDbOptionEnum, InitDbOptionEnum.SQLITE)
+    result = app(args=cli_args, standalone_mode=False)
+    if isinstance(result, SimpleNamespace):
         return result
-    except typer.Exit as exc:  # pragma: no cover - CLI exit paths
-        raise SystemExit(exc.exit_code) from exc
+    return SimpleNamespace(init_db=None)
+
+
+from typing import Annotated

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -18,17 +18,17 @@
 # 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
 
 # Basic configuration
-PLATFORM = "xhs"  # Platform, xhs | dy | ks | bili | wb | tieba | zhihu
+PLATFORM = "bili"
 
 # 是否使用海外版小红书 (rednote.com)
 # 开启后 API 走 webapi.rednote.com，cookie 域使用 .rednote.com
 XHS_INTERNATIONAL = False
 
-KEYWORDS = "编程副业,编程兼职"  # Keyword search configuration, separated by English commas
+KEYWORDS = "恋爱tips"  # Keyword search configuration, separated by English commas
 LOGIN_TYPE = "qrcode"  # qrcode or phone or cookie
 COOKIES = ""
 CRAWLER_TYPE = (
-    "search"  # Crawling type, search (keyword search) | detail (post details) | creator (creator homepage data)
+    "detail"  # Crawling type, search (keyword search) | detail (post details) | creator (creator homepage data)
 )
 # Whether to enable IP proxy
 ENABLE_IP_PROXY = False
@@ -43,7 +43,7 @@ IP_PROXY_PROVIDER_NAME = "kuaidaili"  # kuaidaili | wandouhttp
 # Setting False will open a browser
 # If Xiaohongshu keeps scanning the code to log in but fails, open the browser and manually pass the sliding verification code.
 # If Douyin keeps prompting failure, open the browser and see if mobile phone number verification appears after scanning the QR code to log in. If it does, manually go through it and try again.
-HEADLESS = False
+HEADLESS = True
 
 # Whether to save login status
 SAVE_LOGIN_STATE = True
@@ -52,7 +52,7 @@ SAVE_LOGIN_STATE = True
 # 是否启用 CDP 模式 - 使用用户本地的 Chrome/Edge 浏览器进行爬取，具有更好的反检测能力
 # 开启后，会自动检测并启动用户的 Chrome/Edge 浏览器，通过 CDP 协议进行控制
 # 该方式使用真实浏览器环境，包括用户的扩展、Cookie 和设置，大幅降低被风控检测的风险
-ENABLE_CDP_MODE = True
+ENABLE_CDP_MODE = False
 
 # CDP 调试端口，用于与浏览器通信
 # 如果端口被占用，系统会自动尝试下一个可用端口
@@ -78,40 +78,39 @@ BROWSER_LAUNCH_TIMEOUT = 60
 # 这种方式反检测效果最好，因为直接使用用户真实浏览器的所有 Cookie、扩展和浏览历史
 CDP_CONNECT_EXISTING = True
 
-# 程序结束时是否自动关闭浏览器
-# 设置为 False 可以保持浏览器运行，方便调试
-AUTO_CLOSE_BROWSER = True
+# Data saving path
+SAVE_DATA_PATH = "/Users/caseypeng/Projects/caseypeng-ai-kit/data/mediacrawler"
 
-# Data saving type option configuration, supports: csv, db, json, jsonl, sqlite, excel, postgres. It is best to save to DB, with deduplication function.
-SAVE_DATA_OPTION = "jsonl"  # csv or db or json or jsonl or sqlite or excel or postgres
+# Data format to save: csv | db | json | jsonl | sqlite | mongodb | excel | postgres
+SAVE_DATA_OPTION = "jsonl"
 
-# Data saving path, if not specified by default, it will be saved to the data folder.
-SAVE_DATA_PATH = ""
+# User data directory for browser profiles
+USER_DATA_DIR = "%s_user_data_dir"
 
-# Browser file configuration cached by the user's browser
-USER_DATA_DIR = "%s_user_data_dir"  # %s will be replaced by platform name
-
-# The number of pages to start crawling starts from the first page by default
+# Start page for crawling
 START_PAGE = 1
 
-# Control the number of crawled videos/posts
-CRAWLER_MAX_NOTES_COUNT = 15
+# Maximum number of notes/posts to crawl
+CRAWLER_MAX_NOTES_COUNT = 10
 
-# Controlling the number of concurrent crawlers
+# Maximum concurrency
 MAX_CONCURRENCY_NUM = 1
 
-# Whether to enable crawling media mode (including image or video resources), crawling media is not enabled by default
+# Whether to get media files
 ENABLE_GET_MEIDAS = False
 
-# Whether to enable comment crawling mode. Comment crawling is enabled by default.
+# Whether to get comments
 ENABLE_GET_COMMENTS = True
 
-# Control the number of crawled first-level comments (single video/post)
+# Maximum comment count per note
 CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES = 10
 
-# Whether to enable the mode of crawling second-level comments. By default, crawling of second-level comments is not enabled.
-# If the old version of the project uses db, you need to refer to schema/tables.sql line 287 to add table fields.
+# Whether to get sub-comments
 ENABLE_GET_SUB_COMMENTS = False
+
+# Cache type
+CACHE_TYPE_MEMORY = "memory"
+CACHE_TYPE_REDIS = "redis"
 
 # word cloud related
 # Whether to enable generating comment word clouds
@@ -143,3 +142,4 @@ from .ks_config import *
 from .weibo_config import *
 from .tieba_config import *
 from .zhihu_config import *
+from .xhh_config import *

--- a/config/xhh_config.py
+++ b/config/xhh_config.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+
+# Xiaoheihe (小黑盒) platform configuration
+
+# 指定帖子 link_id 列表（detail 模式）
+XHH_SPECIFIED_ID_LIST = [
+    # "179403000",
+]
+
+# Cookie 文件路径（qrcode 模式登录后自动保存）
+# 默认使用 ~/.xhh_cookies.json，与 tools/xhh/xhh_crawl.py 共享同一份 Cookie
+XHH_COOKIE_FILE = "~/.xhh_cookies.json"

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ from media_platform.douyin import DouYinCrawler
 from media_platform.kuaishou import KuaishouCrawler
 from media_platform.tieba import TieBaCrawler
 from media_platform.weibo import WeiboCrawler
+from media_platform.xhh import XiaoHeiHeCrawler
 from media_platform.xhs import XiaoHongShuCrawler
 from media_platform.zhihu import ZhihuCrawler
 from tools.async_file_writer import AsyncFileWriter
@@ -56,6 +57,7 @@ class CrawlerFactory:
         "wb": WeiboCrawler,
         "tieba": TieBaCrawler,
         "zhihu": ZhihuCrawler,
+        "xhh": XiaoHeiHeCrawler,
     }
 
     @staticmethod

--- a/media_platform/xhh/__init__.py
+++ b/media_platform/xhh/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+
+from .core import XiaoHeiHeCrawler
+
+__all__ = ["XiaoHeiHeCrawler"]

--- a/media_platform/xhh/core.py
+++ b/media_platform/xhh/core.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+
+# 声明：本代码仅供学习和研究目的使用。使用者应遵守以下原则：
+# 1. 不得用于任何商业用途。
+# 2. 使用时应遵守目标平台的使用条款和robots.txt规则。
+# 3. 不得进行大规模爬取或对平台造成运营干扰。
+# 4. 应合理控制请求频率，避免给目标平台带来不必要的负担。
+# 5. 不得用于任何非法或不当的用途。
+#
+# 详细许可条款请参阅项目根目录下的LICENSE文件。
+# 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
+
+import asyncio
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from playwright.async_api import (
+    BrowserContext,
+    BrowserType,
+    Page,
+    async_playwright,
+)
+
+import config
+from base.base_crawler import AbstractCrawler
+from store import xhh as xhh_store
+from tools import utils
+
+from .login import XiaoHeiHeLogin
+
+
+class XiaoHeiHeCrawler(AbstractCrawler):
+    """小黑盒（XiaoHeiHe）爬虫核心类
+
+    支持 detail 模式：抓取指定 link_id 帖子的详情（标题、正文、图片、作者等）。
+
+    技术方案：
+    - 使用 Playwright 渲染页面，通过拦截 /bbs/app/link/tree API 获取结构化数据
+    - 登录态通过 Cookie 文件（~/.xhh_cookies.json）或二维码扫码维持
+    - 二维码登录：打开首页点击登录按鈕触发 get_qrcode_url API，弹出 PIL 图片窗口供扫码
+    - 签名算法（hkey）由 Playwright 页面 JS 自动处理，无需手动实现
+    """
+
+    context_page: Page
+    browser_context: BrowserContext
+
+    def __init__(self) -> None:
+        self.index_url = "https://www.xiaoheihe.cn/app/bbs/home"
+        self.user_agent = (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/126.0.0.0 Safari/537.36"
+        )
+
+    async def start(self) -> None:
+        """启动爬虫主流程"""
+        async with async_playwright() as playwright:
+            self.browser_context = await self.launch_browser(
+                playwright.chromium,
+                None,
+                self.user_agent,
+                headless=config.HEADLESS,
+            )
+
+            # 注入反检测脚本
+            stealth_js = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+                "libs", "stealth.min.js",
+            )
+            if os.path.exists(stealth_js):
+                await self.browser_context.add_init_script(path=stealth_js)
+
+            self.context_page = await self.browser_context.new_page()
+
+            # 拦截 get_qrcode_url API，将 qr_url 注入页面全局变量供 login.py 读取
+            await self.context_page.route(
+                "**/account/get_qrcode_url/**",
+                self._handle_qrcode_url,
+            )
+
+            # 登录
+            login_obj = XiaoHeiHeLogin(
+                login_type=config.LOGIN_TYPE,
+                browser_context=self.browser_context,
+                context_page=self.context_page,
+            )
+            await login_obj.begin()
+
+            # 保存登录态
+            if config.SAVE_LOGIN_STATE:
+                await self._save_login_state()
+
+            utils.logger.info(
+                f"[XiaoHeiHeCrawler.start] Login OK, crawler_type={config.CRAWLER_TYPE}"
+            )
+
+            if config.CRAWLER_TYPE == "detail":
+                await self.get_specified_posts()
+            else:
+                utils.logger.warning(
+                    f"[XiaoHeiHeCrawler.start] Unsupported crawler_type={config.CRAWLER_TYPE}. "
+                    "Only 'detail' is supported for xiaoheihe."
+                )
+
+            await self.context_page.close()
+            await self.browser_context.close()
+
+    async def _handle_qrcode_url(self, route, request) -> None:
+        """拦截 get_qrcode_url API，将 qr_url 写入页面 JS 全局变量"""
+        response = await route.fetch()
+        try:
+            body = await response.json()
+            qr_url = body.get("result", {}).get("qr_url", "")
+            if qr_url:
+                await self.context_page.evaluate(
+                    f"() => {{ window.__xhh_qr_url__ = {json.dumps(qr_url)}; }}"
+                )
+        except Exception:
+            pass
+        await route.fulfill(response=response)
+
+    async def _save_login_state(self) -> None:
+        """保存登录 Cookie 到 XHH_COOKIE_FILE"""
+        cookie_file = Path(os.path.expanduser(config.XHH_COOKIE_FILE))
+        cookies = await self.browser_context.cookies()
+        cookie_file.write_text(json.dumps(cookies, ensure_ascii=False, indent=2))
+        utils.logger.info(f"[XiaoHeiHeCrawler] Login state saved to {cookie_file}")
+
+    async def search(self) -> None:
+        """关键词搜索（小黑盒暂不支持）"""
+        utils.logger.warning(
+            "[XiaoHeiHeCrawler.search] Keyword search not supported for xiaoheihe."
+        )
+
+    async def get_specified_posts(self) -> None:
+        """抓取 XHH_SPECIFIED_ID_LIST 中指定的帖子详情"""
+        link_id_list: List[str] = config.XHH_SPECIFIED_ID_LIST
+        if not link_id_list:
+            utils.logger.warning(
+                "[XiaoHeiHeCrawler.get_specified_posts] "
+                "XHH_SPECIFIED_ID_LIST is empty. Please set it in config/xhh_config.py"
+            )
+            return
+
+        utils.logger.info(
+            f"[XiaoHeiHeCrawler.get_specified_posts] Fetching {len(link_id_list)} posts ..."
+        )
+
+        # 顺序抓取（小黑盒风控较严，避免并发触发验证码）
+        for link_id in link_id_list:
+            result = await self.fetch_post_detail(link_id)
+            if result:
+                await xhh_store.update_xhh_post(result)
+            await asyncio.sleep(config.CRAWLER_MAX_SLEEP_SEC)
+
+    async def fetch_post_detail(self, link_id: str) -> Optional[Dict]:
+        """抓取单个帖子详情
+
+        使用 expect_response() 同步等待 /bbs/app/link/tree API 响应。
+        登录态由浏览器 Cookie 自动携带，无需手动签名。
+
+        Args:
+            link_id: 小黑盒帖子 ID（URL 末段数字）
+
+        Returns:
+            规范化的帖子字典，失败时返回 None
+        """
+        utils.logger.info(
+            f"[XiaoHeiHeCrawler.fetch_post_detail] Fetching link_id={link_id}"
+        )
+        url = f"https://www.xiaoheihe.cn/app/bbs/link/{link_id}"
+
+        try:
+            async with self.context_page.expect_response(
+                lambda r: "/bbs/app/link/tree" in r.url and r.status == 200,
+                timeout=20000,
+            ) as resp_info:
+                await self.context_page.goto(
+                    url, wait_until="domcontentloaded", timeout=25000
+                )
+
+            response = await resp_info.value
+            body = await response.json()
+
+            if body.get("status") != "ok":
+                utils.logger.warning(
+                    f"[XiaoHeiHeCrawler.fetch_post_detail] "
+                    f"API status={body.get('status')} for link_id={link_id}"
+                )
+                return None
+
+            post_data = body.get("result", {})
+            normalized = _normalize_post(post_data, link_id)
+            utils.logger.info(
+                f"[XiaoHeiHeCrawler.fetch_post_detail] "
+                f"title={normalized.get('title', '')[:40]}"
+            )
+            return normalized
+
+        except Exception as e:
+            utils.logger.warning(
+                f"[XiaoHeiHeCrawler.fetch_post_detail] "
+                f"Failed for link_id={link_id}: {e}"
+            )
+            return None
+
+    async def launch_browser(
+        self,
+        chromium: BrowserType,
+        playwright_proxy: Optional[Dict],
+        user_agent: Optional[str],
+        headless: bool = True,
+    ) -> BrowserContext:
+        """启动 Chromium 浏览器"""
+        utils.logger.info(
+            f"[XiaoHeiHeCrawler.launch_browser] "
+            f"headless={headless}, proxy={'yes' if playwright_proxy else 'no'}"
+        )
+        browser = await chromium.launch(headless=headless, proxy=playwright_proxy)
+        return await browser.new_context(
+            viewport={"width": 1280, "height": 800},
+            user_agent=user_agent,
+        )
+
+    async def close(self) -> None:
+        await self.browser_context.close()
+
+
+# ─── 数据规范化 ────────────────────────────────────────────────────────────────────────────
+
+def _normalize_post(api_result: Dict, link_id: str) -> Dict:
+    """将小黑盒 link/tree API 返回结构规范化为统一存储字段
+
+    Args:
+        api_result: API response["result"] 字典
+        link_id:    帖子 ID
+
+    Returns:
+        扁平化的帖子字典，供 store.xhh.update_xhh_post 存储
+    """
+    post = (
+        api_result.get("post_data")
+        or api_result.get("heylink")
+        or api_result.get("link")
+        or api_result.get("data")
+        or api_result
+    )
+
+    # 标题
+    title = post.get("title") or post.get("topic") or post.get("name") or ""
+
+    # 作者
+    author_nickname = ""
+    author_id = ""
+    for key in ("user", "author", "creator"):
+        author_obj = post.get(key, {})
+        if isinstance(author_obj, dict):
+            author_nickname = author_obj.get("nickname") or author_obj.get("name") or ""
+            author_id = str(author_obj.get("user_id") or author_obj.get("id") or "")
+            if author_nickname:
+                break
+
+    # 正文 & 图片（富文本块格式：[{"type": "html"|"img"|"text", ...}]）
+    raw_content = post.get("content") or post.get("desc") or post.get("text") or ""
+    content_parts: List[str] = []
+    images: List[str] = []
+
+    def _parse_blocks(blocks: list) -> None:
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "html":
+                clean = re.sub(r"<[^>]+>", "", block.get("text", "")).strip()
+                clean = re.sub(r"\n{3,}", "\n\n", clean)
+                if clean:
+                    content_parts.append(clean)
+            elif btype == "img":
+                img_url = block.get("url") or block.get("src") or ""
+                if img_url:
+                    images.append(img_url)
+            elif btype == "text":
+                t = block.get("text", "").strip()
+                if t:
+                    content_parts.append(t)
+
+    if isinstance(raw_content, list):
+        _parse_blocks(raw_content)
+    elif isinstance(raw_content, str) and raw_content.strip().startswith("["):
+        try:
+            _parse_blocks(json.loads(raw_content))
+        except (json.JSONDecodeError, Exception):
+            content_parts.append(re.sub(r"<[^>]+>", "", raw_content).strip())
+    elif raw_content:
+        content_parts.append(re.sub(r"<[^>]+>", "", str(raw_content)).strip())
+
+    # 从其他字段补充图片列表
+    if not images:
+        for img_key in ("image_list", "images", "pics", "image"):
+            img_list = post.get(img_key, [])
+            if isinstance(img_list, list) and img_list:
+                for img in img_list:
+                    if isinstance(img, dict):
+                        for size_key in ("origin", "large", "url", "src"):
+                            if img.get(size_key):
+                                images.append(img[size_key])
+                                break
+                    elif isinstance(img, str):
+                        images.append(img)
+                break
+
+    content_type = (
+        "video" if (post.get("video") or post.get("video_url"))
+        else "image_text" if images
+        else "article"
+    )
+
+    interact = post.get("interact_info") or post.get("stats") or {}
+
+    return {
+        "link_id": str(link_id),
+        "title": title,
+        "content": "\n\n".join(content_parts),
+        "content_type": content_type,
+        "image_list": ",".join(images),
+        "author_id": author_id,
+        "author_nickname": author_nickname,
+        "like_count": str(interact.get("like_count") or interact.get("liked_count") or 0),
+        "comment_count": str(interact.get("comment_count") or 0),
+        "share_count": str(interact.get("share_count") or 0),
+        "post_time": str(post.get("create_time") or post.get("time") or 0),
+        "url": f"https://www.xiaoheihe.cn/app/bbs/link/{link_id}",
+        "last_modify_ts": str(utils.get_current_timestamp()),
+    }

--- a/media_platform/xhh/login.py
+++ b/media_platform/xhh/login.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+
+# 声明：本代码仅供学习和研究目的使用。使用者应遵守以下原则：
+# 1. 不得用于任何商业用途。
+# 2. 使用时应遵守目标平台的使用条款和robots.txt规则。
+# 3. 不得进行大规模爬取或对平台造成运营干扰。
+# 4. 应合理控制请求频率，避免给目标平台带来不必要的负担。
+# 5. 不得用于任何非法或不当的用途。
+#
+# 详细许可条款请参阅项目根目录下的LICENSE文件。
+# 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from playwright.async_api import BrowserContext, Page
+from tenacity import RetryError, retry, retry_if_result, stop_after_attempt, wait_fixed
+
+import config
+from base.base_crawler import AbstractLogin
+from tools import utils
+
+
+class XiaoHeiHeLogin(AbstractLogin):
+    """小黑盒登录实现
+
+    支持两种登录方式：
+    - qrcode: 弹出二维码图片，用小黑盒 APP 扫码登录
+    - cookie: 直接使用已保存的 Cookie 文件
+    """
+
+    def __init__(
+        self,
+        login_type: str,
+        browser_context: BrowserContext,
+        context_page: Page,
+        login_phone: Optional[str] = "",
+        cookie_str: str = "",
+    ):
+        config.LOGIN_TYPE = login_type
+        self.browser_context = browser_context
+        self.context_page = context_page
+        self.login_phone = login_phone
+        self.cookie_str = cookie_str
+
+    @retry(
+        stop=stop_after_attempt(300),
+        wait=wait_fixed(1),
+        retry=retry_if_result(lambda v: v is False),
+    )
+    async def check_login_state(self, no_logged_in_session: str) -> bool:
+        """轮询检测登录态：检查 heybox_id cookie 是否出现"""
+        current_cookies = await self.browser_context.cookies()
+        cookie_dict = {c["name"]: c["value"] for c in current_cookies}
+        heybox_id = cookie_dict.get("heybox_id", "")
+        if heybox_id and heybox_id != no_logged_in_session:
+            utils.logger.info(
+                "[XiaoHeiHeLogin.check_login_state] Login confirmed by heybox_id cookie."
+            )
+            return True
+        return False
+
+    async def begin(self):
+        """Start login xiaoheihe"""
+        utils.logger.info("[XiaoHeiHeLogin.begin] Begin login xiaoheihe ...")
+        if config.LOGIN_TYPE == "qrcode":
+            await self.login_by_qrcode()
+        elif config.LOGIN_TYPE == "cookie":
+            await self.login_by_cookies()
+        else:
+            raise ValueError(
+                "[XiaoHeiHeLogin.begin] Invalid login type. Supported: qrcode | cookie"
+            )
+
+    async def login_by_mobile(self):
+        """小黑盒不支持手机验证码登录，留空实现接口"""
+        utils.logger.warning(
+            "[XiaoHeiHeLogin.login_by_mobile] Mobile login not supported for xiaoheihe."
+        )
+
+    async def login_by_qrcode(self):
+        """通过扫码登录小黑盒
+
+        流程：
+        1. 打开小黑盒首页并点击登录按鈕，触发 get_qrcode_url API
+        2. 拦截 API 获取 qr_url（小黑盒 APP 可识别的格式）
+        3. 生成二维码图片弹窗（PIL）供用户扫码
+        4. 轮询检测 heybox_id cookie 出现，确认登录成功
+        """
+        utils.logger.info(
+            "[XiaoHeiHeLogin.login_by_qrcode] Begin login xiaoheihe by qrcode ..."
+        )
+
+        # 导航到首页并点击登录
+        home_url = "https://www.xiaoheihe.cn/app/bbs/home"
+        try:
+            await self.context_page.goto(home_url, wait_until="networkidle", timeout=20000)
+            await asyncio.sleep(0.5)
+            await self.context_page.click(".user-box__login")
+        except Exception as e:
+            utils.logger.warning(
+                f"[XiaoHeiHeLogin.login_by_qrcode] Failed to click login button: {e}"
+            )
+
+        # 等待 get_qrcode_url API 响应（最多 8 秒）
+        qr_url = None
+        for _ in range(16):
+            await asyncio.sleep(0.5)
+            # 从拦截到的 API 响应中取 qr_url（由 core.py 在启动时注入到 page 对象）
+            qr_url = await self.context_page.evaluate(
+                "() => window.__xhh_qr_url__ || null"
+            )
+            if qr_url:
+                break
+
+        if not qr_url:
+            utils.logger.error(
+                "[XiaoHeiHeLogin.login_by_qrcode] Failed to get qr_url from API."
+            )
+            sys.exit(1)
+
+        utils.logger.info(
+            f"[XiaoHeiHeLogin.login_by_qrcode] Got qr_url, generating QR code ..."
+        )
+
+        # 生成二维码图片并弹窗（在线程池中运行，不阻塞事件循环）
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _show_qrcode, qr_url)
+
+        # 获取登录前的 heybox_id（可能为空）
+        current_cookies = await self.browser_context.cookies()
+        cookie_dict = {c["name"]: c["value"] for c in current_cookies}
+        no_logged_in_session = cookie_dict.get("heybox_id", "")
+
+        utils.logger.info(
+            "[XiaoHeiHeLogin.login_by_qrcode] Waiting for QR code scan (max 120s) ..."
+        )
+        try:
+            await self.check_login_state(no_logged_in_session)
+        except RetryError:
+            utils.logger.error(
+                "[XiaoHeiHeLogin.login_by_qrcode] Login timed out. Please retry."
+            )
+            sys.exit(1)
+
+        wait_redirect_seconds = 3
+        utils.logger.info(
+            f"[XiaoHeiHeLogin.login_by_qrcode] Login successful, "
+            f"waiting {wait_redirect_seconds}s for redirect ..."
+        )
+        await asyncio.sleep(wait_redirect_seconds)
+
+    async def login_by_cookies(self):
+        """通过 Cookie 文件登录小黑盒
+
+        读取 ~/.xhh_cookies.json（由 tools/xhh/xhh_crawl.py --login 生成），
+        将所有 cookie 注入到当前浏览器上下文。
+        """
+        utils.logger.info(
+            "[XiaoHeiHeLogin.login_by_cookies] Begin login xiaoheihe by cookies ..."
+        )
+        cookie_file = Path(os.path.expanduser(config.XHH_COOKIE_FILE))
+        if not cookie_file.exists():
+            utils.logger.error(
+                f"[XiaoHeiHeLogin.login_by_cookies] Cookie file not found: {cookie_file}. "
+                "Run 'python main.py --platform xhh --lt qrcode' to login first."
+            )
+            sys.exit(1)
+
+        try:
+            cookies = json.loads(cookie_file.read_text())
+        except Exception as e:
+            utils.logger.error(
+                f"[XiaoHeiHeLogin.login_by_cookies] Failed to parse cookie file: {e}"
+            )
+            sys.exit(1)
+
+        # 只注入 xiaoheihe.cn 域的 cookie
+        xhh_cookies = [
+            c for c in cookies
+            if "xiaoheihe" in c.get("domain", "") or "heybox" in c.get("domain", "")
+        ]
+        if not xhh_cookies:
+            # 如果没有筛选到，注入全部（兼容旧格式）
+            xhh_cookies = cookies
+
+        await self.browser_context.add_cookies(xhh_cookies)
+        utils.logger.info(
+            f"[XiaoHeiHeLogin.login_by_cookies] Injected {len(xhh_cookies)} cookies."
+        )
+
+
+def _show_qrcode(qr_url: str) -> None:
+    """生成二维码图片并弹窗显示（同步函数，在线程池中调用）"""
+    try:
+        import qrcode as qrcode_lib
+        from PIL import Image
+    except ImportError:
+        utils.logger.warning(
+            "[XiaoHeiHeLogin] qrcode or PIL not installed. "
+            "Install with: pip install qrcode[pil] pillow"
+        )
+        utils.logger.info(f"[XiaoHeiHeLogin] Please scan this URL manually: {qr_url}")
+        return
+
+    qr = qrcode_lib.QRCode(box_size=8, border=3)
+    qr.add_data(qr_url)
+    qr.make(fit=True)
+    qr_img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
+
+    w, h = qr_img.size
+    canvas = Image.new("RGB", (w, h + 16), color=(255, 255, 255))
+    canvas.paste(qr_img, (0, 0))
+    canvas.show(title="小黑盒扫码登录 — 打开小黑盒 APP 扫一扫")
+    utils.logger.info("[XiaoHeiHeLogin] QR code window opened. Please scan with xiaoheihe APP.")

--- a/store/xhh/__init__.py
+++ b/store/xhh/__init__.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+
+# 声明：本代码仅供学习和研究目的使用。使用者应遵守以下原则：
+# 1. 不得用于任何商业用途。
+# 2. 使用时应遵守目标平台的使用条款和robots.txt规则。
+# 3. 不得进行大规模爬取或对平台造成运营干扰。
+# 4. 应合理控制请求频率，避免给目标平台带来不必要的负担。
+# 5. 不得用于任何非法或不当的用途。
+#
+# 详细许可条款请参阅项目根目录下的LICENSE文件。
+# 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
+
+from typing import Dict
+
+import config
+from tools import utils
+
+from ._store_impl import (
+    XhhCsvStoreImplement,
+    XhhJsonStoreImplement,
+    XhhJsonlStoreImplement,
+)
+
+
+class XhhStoreFactory:
+    STORES = {
+        "csv": XhhCsvStoreImplement,
+        "json": XhhJsonStoreImplement,
+        "jsonl": XhhJsonlStoreImplement,
+    }
+
+    @staticmethod
+    def create_store():
+        store_class = XhhStoreFactory.STORES.get(config.SAVE_DATA_OPTION)
+        if not store_class:
+            # 默认 jsonl
+            store_class = XhhJsonlStoreImplement
+        return store_class()
+
+
+async def update_xhh_post(post_item: Dict):
+    """
+    Store xiaoheihe post data
+    Args:
+        post_item: normalized post dict from core._normalize_post()
+    """
+    utils.logger.info(
+        f"[store.xhh.update_xhh_post] Storing post link_id={post_item.get('link_id')}"
+    )
+    await XhhStoreFactory.create_store().store_content(post_item)

--- a/store/xhh/_store_impl.py
+++ b/store/xhh/_store_impl.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+
+# 声明：本代码仅供学习和研究目的使用。使用者应遵守以下原则：
+# 1. 不得用于任何商业用途。
+# 2. 使用时应遵守目标平台的使用条款和robots.txt规则。
+# 3. 不得进行大规模爬取或对平台造成运营干扰。
+# 4. 应合理控制请求频率，避免给目标平台带来不必要的负担。
+# 5. 不得用于任何非法或不当的用途。
+#
+# 详细许可条款请参阅项目根目录下的LICENSE文件。
+# 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
+
+from typing import Dict
+
+from base.base_crawler import AbstractStore
+from tools.async_file_writer import AsyncFileWriter
+from var import crawler_type_var
+
+
+class XhhCsvStoreImplement(AbstractStore):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.writer = AsyncFileWriter(platform="xhh", crawler_type=crawler_type_var.get())
+
+    async def store_content(self, content_item: Dict):
+        """Store post data to CSV file"""
+        await self.writer.write_to_csv(item_type="contents", item=content_item)
+
+    async def store_comment(self, comment_item: Dict):
+        """Store comment data to CSV file"""
+        await self.writer.write_to_csv(item_type="comments", item=comment_item)
+
+    async def store_creator(self, creator_item: Dict):
+        pass
+
+    def flush(self):
+        pass
+
+
+class XhhJsonStoreImplement(AbstractStore):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.writer = AsyncFileWriter(platform="xhh", crawler_type=crawler_type_var.get())
+
+    async def store_content(self, content_item: Dict):
+        """Store post data to JSON file"""
+        await self.writer.write_single_item_to_json(item_type="contents", item=content_item)
+
+    async def store_comment(self, comment_item: Dict):
+        """Store comment data to JSON file"""
+        await self.writer.write_single_item_to_json(item_type="comments", item=comment_item)
+
+    async def store_creator(self, creator_item: Dict):
+        pass
+
+    def flush(self):
+        pass
+
+
+class XhhJsonlStoreImplement(AbstractStore):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.writer = AsyncFileWriter(platform="xhh", crawler_type=crawler_type_var.get())
+
+    async def store_content(self, content_item: Dict):
+        """Store post data to JSONL file"""
+        await self.writer.write_to_jsonl(item_type="contents", item=content_item)
+
+    async def store_comment(self, comment_item: Dict):
+        """Store comment data to JSONL file"""
+        await self.writer.write_to_jsonl(item_type="comments", item=comment_item)
+
+    async def store_creator(self, creator_item: Dict):
+        pass
+
+    def flush(self):
+        pass


### PR DESCRIPTION
## Summary

Add **XiaoHeiHe** (小黑盒, xiaoheihe.cn) as a new crawling platform in MediaCrawler.

小黑盒 is a popular Chinese gaming community platform. This PR adds support for crawling post details (title, content, images, author) from xiaoheihe.cn.

## New Files

| File | Description |
|------|-------------|
| `media_platform/xhh/__init__.py` | Module entry point |
| `media_platform/xhh/core.py` | `XiaoHeiHeCrawler` — Playwright-based crawler using API interception |
| `media_platform/xhh/login.py` | `XiaoHeiHeLogin` — QR code scan login + cookie file login |
| `store/xhh/__init__.py` | `XhhStoreFactory` + `update_xhh_post()` |
| `store/xhh/_store_impl.py` | CSV / JSON / JSONL storage implementations |
| `config/xhh_config.py` | `XHH_SPECIFIED_ID_LIST`, `XHH_COOKIE_FILE` |

## Modified Files

- `main.py` — Register `XiaoHeiHeCrawler` in `CrawlerFactory`
- `cmd_arg/arg.py` — Add `xhh` to `PlatformEnum`
- `config/base_config.py` — Import `xhh_config`

## Technical Approach

- **API interception**: Uses Playwright’s `expect_response()` to synchronously wait for the `/bbs/app/link/tree` API, which returns structured post data (no manual signature needed — the page JS handles `hkey` signing automatically)
- **Login**: QR code login pops up a PIL image window; users scan with the XiaoHeiHe APP. Cookie is saved to `~/.xhh_cookies.json` for reuse
- **Content parsing**: Handles XiaoHeiHe’s rich-text block format `[{"type": "html"|"img"|"text", ...}]`

## Usage

```bash
# First-time login (pops QR code window)
python main.py --platform xhh --lt qrcode --type detail

# Subsequent runs (reuse saved cookie)
python main.py --platform xhh --lt cookie --type detail
```

Configure post IDs in `config/xhh_config.py`:
```python
XHH_SPECIFIED_ID_LIST = ["179403000", "123456789"]
```