### PR TITLE
Fix: skip notes that fail to fetch instead of crashing

### DIFF
--- a/media_platform/xhs/core.py
+++ b/media_platform/xhs/core.py
@@ -302,7 +302,8 @@ class XiaoHongShuCrawler(AbstractCrawler):
                     note_detail = await self.xhs_client.get_note_by_id_from_html(note_id, xsec_source, xsec_token,
                                                                                  enable_cookie=True)
                     if not note_detail:
-                        raise Exception(f"[get_note_detail_async_task] Failed to get note detail, Id: {note_id}")
+                        utils.logger.warning(f"[skip] Failed to get note detail, Id: {note_id}, 跳过继续")
+                        return None
 
                 note_detail.update({"xsec_token": xsec_token, "xsec_source": xsec_source})
 


### PR DESCRIPTION
## Problem

When `get_note_by_id_from_html` returns empty for a single note (e.g. due to rate limit or anti-bot), the original code raises an `Exception` which crashes the entire crawler run.

## Solution

Replace the `raise Exception(...)` with a `utils.logger.warning(...)` and `return None`, so the crawler skips that note and continues with the rest.

## Test

Tested locally on `xhs` platform with 13 keywords. Previously crashed after 1-5 notes, now runs through full keyword list successfully.