### PR TITLE
fix: 修复知乎 specified_id 和已有 Chrome CDP 连接问题

### DIFF
--- a/cmd_arg/arg.py
+++ b/cmd_arg/arg.py
@@ -382,6 +382,8 @@ async def parse_cmd(argv: Optional[Sequence[str]] = None):
                 config.TIEBA_SPECIFIED_ID_LIST = [
                     _normalize_tieba_note_id(item) for item in specified_id_list
                 ]
+            elif platform == PlatformEnum.ZHIHU:
+                config.ZHIHU_SPECIFIED_ID_LIST = specified_id_list
 
         if creator_id_list:
             if platform == PlatformEnum.XHS:

--- a/tools/cdp_browser.py
+++ b/tools/cdp_browser.py
@@ -316,10 +316,9 @@ class CDPBrowserManager:
         """
         try:
             if config.CDP_CONNECT_EXISTING:
-                # For existing browser (e.g. chrome://inspect/#remote-debugging),
-                # Chrome exposes a WebSocket at /devtools/browser and may show a confirmation
-                # dialog to the user. Use ws:// with a longer timeout to wait for user confirmation.
-                ws_url = f"ws://localhost:{self.debug_port}/devtools/browser"
+                # Existing Chrome exposes the browser websocket URL from /json/version.
+                # Newer Chrome versions return a UUID path instead of plain /devtools/browser.
+                ws_url = await self._get_browser_websocket_url(self.debug_port)
                 utils.logger.info(f"[CDPBrowserManager] Connecting to existing browser via CDP: {ws_url}")
                 utils.logger.info(
                     "[CDPBrowserManager] Please check your browser for a confirmation dialog and accept it"


### PR DESCRIPTION
## 修改内容

修复两个知乎 detail / CDP 相关问题：

1. 知乎平台现在会正确使用命令行传入的 `--specified_id`。
2. `CDP_CONNECT_EXISTING=True` 时，不再写死 `ws://localhost:{port}/devtools/browser`，改为从 `/json/version` 读取真实 `webSocketDebuggerUrl`。

## 背景

相关 issue：#908

## 验证

本地使用以下命令验证通过：

```bash
uv run main.py \
  --platform zhihu \
  --lt qrcode \
  --type detail \
  --specified_id https://www.zhihu.com/question/1903453201698619711/answer/1949227241444730016 \
  --get_comment true \
  --get_sub_comment true \
  --save_data_option jsonl \
  --save_data_path ./data \
  --max_comments_count_singlenotes 5
```

修复后日志显示：

```text
[CDPBrowserManager] Successfully connected to browser
[ZhihuCrawler.get_specified_notes] Begin get specified note ...
[store.zhihu.update_zhihu_content] zhihu content: ...
[store.zhihu.update_zhihu_note_comment] zhihu content comment: ...
[ZhihuCrawler.start] Zhihu Crawler finished ...
```

## 兼容性

- 不影响未传 `--specified_id` 的配置文件模式。
- 不影响其他平台。
- CDP existing browser 模式仍然连接同一个端口，只是使用 Chrome 返回的真实 websocket 地址。

Fixes #908