### PR TITLE
feat: douyin增加按时间段爬取数据(search/creator)

### DIFF
--- a/config/dy_config.py
+++ b/config/dy_config.py
@@ -19,6 +19,17 @@
 
 # Douyin platform configuration
 PUBLISH_TIME_TYPE = 0
+SEARCH_SORT_TYPE = 0
+# Control the time period of crawled videos/posts 
+# CRAWLER_MAX_NOTES_COUNT and SINCE_TIME(desc), which hit first count
+# dy only right now 
+# search and creator mode only
+# will overwrite config.SORT_TYPE to "time_descending"
+ENABLE_TIME_CRAWL = True
+SINCE_TIME = "2026-04-01 00:00:00"
+UNTIL_TIME = "2026-07-01 00:00:00"
+if ENABLE_TIME_CRAWL:
+    SEARCH_SORT_TYPE = 2
 
 # Specify DY video URL list (supports multiple formats)
 # Supported formats:

--- a/media_platform/douyin/client.py
+++ b/media_platform/douyin/client.py
@@ -20,6 +20,7 @@
 import asyncio
 import copy
 import json
+import config
 import urllib.parse
 from typing import TYPE_CHECKING, Any, Callable, Dict, Union, Optional
 
@@ -329,15 +330,34 @@ class DouYinClient(AbstractApiClient, ProxyRefreshMixin):
         }
         return await self.get(uri, params)
 
+    @staticmethod
+    def filter_aweme_time(aweme_list):
+        filtered_aweme_list = []
+        stop_time_hit = False
+        end_time = utils.get_unix_time_from_time_str(config.UNTIL_TIME)
+        start_time = utils.get_unix_time_from_time_str(config.SINCE_TIME)
+        for aweme_info in aweme_list:
+            # time rule filter
+            if config.ENABLE_TIME_CRAWL and ( start_time > aweme_info.get('create_time')  or aweme_info.get('create_time') > end_time):
+                # stop paging flag filter (除去广告和置顶视频)
+                if aweme_info.get('create_time') < start_time and not aweme_info.get('is_ads', False) and not aweme_info.get('is_top', 0):
+                    stop_time_hit = True
+                    break
+                continue
+            filtered_aweme_list.append(aweme_info)
+        return filtered_aweme_list, stop_time_hit
+
     async def get_all_user_aweme_posts(self, sec_user_id: str, callback: Optional[Callable] = None):
         posts_has_more = 1
         max_cursor = ""
         result = []
-        while posts_has_more == 1:
+        stop_time_hit = False
+        while posts_has_more == 1 and not stop_time_hit:
             aweme_post_res = await self.get_user_aweme_posts(sec_user_id, max_cursor)
             posts_has_more = aweme_post_res.get("has_more", 0)
             max_cursor = aweme_post_res.get("max_cursor")
-            aweme_list = aweme_post_res.get("aweme_list") if aweme_post_res.get("aweme_list") else []
+            aweme_list = aweme_post_res.get("aweme_list") or []
+            aweme_list, stop_time_hit = self.filter_aweme_time(aweme_list)
             utils.logger.info(f"[DouYinClient.get_all_user_aweme_posts] get sec_user_id:{sec_user_id} video len : {len(aweme_list)}")
             if callback:
                 await callback(aweme_list)

--- a/media_platform/douyin/core.py
+++ b/media_platform/douyin/core.py
@@ -41,7 +41,7 @@ from var import crawler_type_var, source_keyword_var
 
 from .client import DouYinClient
 from .exception import DataFetchError
-from .field import PublishTimeType
+from .field import PublishTimeType, SearchSortType
 from .help import parse_video_info_from_url, parse_creator_info_from_url
 from .login import DouYinLogin
 
@@ -136,7 +136,10 @@ class DouYinCrawler(AbstractCrawler):
             aweme_list: List[str] = []
             page = 0
             dy_search_id = ""
-            while (page - start_page + 1) * dy_limit_count <= config.CRAWLER_MAX_NOTES_COUNT:
+            stop_time_hit = False
+            end_time = utils.get_unix_time_from_time_str(config.UNTIL_TIME)
+            start_time = utils.get_unix_time_from_time_str(config.SINCE_TIME)
+            while (page - start_page + 1) * dy_limit_count <= config.CRAWLER_MAX_NOTES_COUNT and not stop_time_hit:
                 if page < start_page:
                     utils.logger.info(f"[DouYinCrawler.search] Skip {page}")
                     page += 1
@@ -147,6 +150,7 @@ class DouYinCrawler(AbstractCrawler):
                         keyword=keyword,
                         offset=page * dy_limit_count - dy_limit_count,
                         publish_time=PublishTimeType(config.PUBLISH_TIME_TYPE),
+                        sort_type=SearchSortType(config.SEARCH_SORT_TYPE),
                         search_id=dy_search_id,
                     )
                     if posts_res.get("data") is None or posts_res.get("data") == []:
@@ -166,6 +170,13 @@ class DouYinCrawler(AbstractCrawler):
                     try:
                         aweme_info: Dict = (post_item.get("aweme_info") or post_item.get("aweme_mix_info", {}).get("mix_items")[0])
                     except TypeError:
+                        continue
+                    # time rule filter
+                    if config.ENABLE_TIME_CRAWL and ( start_time > aweme_info.get('create_time')  or aweme_info.get('create_time') > end_time):
+                        # stop paging flag filter
+                        if start_time > aweme_info.get('create_time'):
+                            stop_time_hit = True
+                            break
                         continue
                     aweme_list.append(aweme_info.get("aweme_id", ""))
                     page_aweme_list.append(aweme_info.get("aweme_id", ""))


### PR DESCRIPTION
## 背景：
有些需求需要按时间段过滤 比如采集一个自然年的视频等
当前配置暂不支持时间段过滤视频
## 增加配置：
ENABLE_TIME_CRAWL = True
SINCE_TIME = "2026-04-01 00:00:00"
UNTIL_TIME = "2026-07-01 00:00:00"
搜索时转换成按时间降序排列 过滤作品时间
小于UNTIL_TIME开始记录 SINCE_TIME停止
