### PR TITLE
feat(webui): persist crawler configuration and expose crawl limits

### DIFF
--- a/webui/src/components/config/CrawlerConfigPanel.tsx
+++ b/webui/src/components/config/CrawlerConfigPanel.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType, ReactNode, KeyboardEvent } from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Database, Globe, KeyRound, MessageSquare, Play, Square, X } from 'lucide-react'
+import { Database, Globe, KeyRound, MessageSquare, Play, SlidersHorizontal, Square, X } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
@@ -131,6 +131,12 @@ function KeywordInput({ value, onChange, placeholder, disabled }: KeywordInputPr
   )
 }
 
+function clampLimit(value: string, fallback: number): number {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(10000, Math.max(1, parsed))
+}
+
 export function CrawlerConfigPanel() {
   const { t } = useTranslation('config')
   const config = useCrawlerStore((state) => state.config)
@@ -145,6 +151,16 @@ export function CrawlerConfigPanel() {
   const isDisabled = status === 'running' || status === 'stopping'
   const isRunning = status === 'running'
   const isBusy = isStarting || isStopping || status === 'stopping'
+  const [maxNotesInput, setMaxNotesInput] = useState(String(config.max_notes_count))
+  const [maxCommentsInput, setMaxCommentsInput] = useState(String(config.max_comments_count))
+
+  useEffect(() => {
+    setMaxNotesInput(String(config.max_notes_count))
+  }, [config.max_notes_count])
+
+  useEffect(() => {
+    setMaxCommentsInput(String(config.max_comments_count))
+  }, [config.max_comments_count])
 
   const handleStart = () => {
     startCrawler(config)
@@ -274,49 +290,106 @@ export function CrawlerConfigPanel() {
           )}
         </Section>
 
-        {/* Column 2: Authentication Section */}
-        <Section
-          title={t('section.authMatrix.title')}
-          description={t('section.authMatrix.description')}
-          icon={KeyRound}
-        >
-          <Field label={t('field.loginMethod')}>
-            <Select
-              value={config.login_type}
-              onValueChange={(value) => updateConfig({ login_type: value })}
-              disabled={isDisabled}
-            >
-              <SelectTrigger className="h-9 text-xs">
-                <SelectValue placeholder={t('field.loginMethodPlaceholder')} />
-              </SelectTrigger>
-              <SelectContent>
-                {options?.login_types.map((type) => (
-                  <SelectItem key={type.value} value={type.value}>
-                    {type.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
-
-          {config.login_type === 'cookie' ? (
-            <Field label={t('field.cookies')} hint={t('field.cookiesHint')}>
-              <textarea
-                value={config.cookies}
-                onChange={(e) => updateConfig({ cookies: e.target.value })}
+        {/* Column 2: Authentication & Crawl Settings */}
+        <div className="grid h-full grid-rows-2 gap-4">
+          <Section
+            title={t('section.authMatrix.title')}
+            description={t('section.authMatrix.description')}
+            icon={KeyRound}
+          >
+            <Field label={t('field.loginMethod')}>
+              <Select
+                value={config.login_type}
+                onValueChange={(value) => updateConfig({ login_type: value })}
                 disabled={isDisabled}
-                placeholder={t('field.cookiesPlaceholder')}
-                className="min-h-[80px] w-full rounded-md border border-cyber-border-DEFAULT bg-cyber-bg-tertiary px-3 py-2 text-xs font-mono text-cyber-text-primary placeholder:text-cyber-text-muted focus-visible:outline-none focus-visible:border-cyber-neon-cyan/50 focus-visible:shadow-cyber-soft disabled:cursor-not-allowed disabled:opacity-50 transition-all resize-none"
-              />
+              >
+                <SelectTrigger className="h-9 text-xs">
+                  <SelectValue placeholder={t('field.loginMethodPlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {options?.login_types.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>
+                      {type.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </Field>
-          ) : null}
 
-          {config.login_type === 'cookie' && (config.platform === 'xhs' || config.platform === 'dy') ? (
-            <div className="rounded-lg border border-cyber-neon-orange/30 bg-cyber-neon-orange/5 p-3 text-[11px] leading-snug text-cyber-neon-orange font-mono">
-              {t('warning.cookieSlider')}
+            {config.login_type === 'cookie' ? (
+              <Field label={t('field.cookies')} hint={t('field.cookiesHint')}>
+                <textarea
+                  value={config.cookies}
+                  onChange={(e) => updateConfig({ cookies: e.target.value })}
+                  disabled={isDisabled}
+                  placeholder={t('field.cookiesPlaceholder')}
+                  className="min-h-[80px] w-full rounded-md border border-cyber-border-DEFAULT bg-cyber-bg-tertiary px-3 py-2 text-xs font-mono text-cyber-text-primary placeholder:text-cyber-text-muted focus-visible:outline-none focus-visible:border-cyber-neon-cyan/50 focus-visible:shadow-cyber-soft disabled:cursor-not-allowed disabled:opacity-50 transition-all resize-none"
+                />
+              </Field>
+            ) : null}
+
+            {config.login_type === 'cookie' && (config.platform === 'xhs' || config.platform === 'dy') ? (
+              <div className="rounded-lg border border-cyber-neon-orange/30 bg-cyber-neon-orange/5 p-3 text-[11px] leading-snug text-cyber-neon-orange font-mono">
+                {t('warning.cookieSlider')}
+              </div>
+            ) : null}
+          </Section>
+
+          <Section
+            title={t('field.crawlConfig')}
+            description={t('field.crawlConfigHint')}
+            icon={SlidersHorizontal}
+          >
+            <div className="grid grid-cols-2 gap-3">
+              <Field label={t('field.maxNotesCount')}>
+                <Input
+                  type="number"
+                  min={1}
+                  max={10000}
+                  value={maxNotesInput}
+                  onChange={(e) => {
+                    const value = e.target.value
+                    setMaxNotesInput(value)
+                    const parsed = Number.parseInt(value, 10)
+                    if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 10000) {
+                      updateConfig({ max_notes_count: parsed })
+                    }
+                  }}
+                  onBlur={() => {
+                    const value = clampLimit(maxNotesInput, config.max_notes_count)
+                    setMaxNotesInput(String(value))
+                    updateConfig({ max_notes_count: value })
+                  }}
+                  disabled={isDisabled}
+                  className="h-9 text-xs"
+                />
+              </Field>
+              <Field label={t('field.maxCommentsCount')}>
+                <Input
+                  type="number"
+                  min={1}
+                  max={10000}
+                  value={maxCommentsInput}
+                  onChange={(e) => {
+                    const value = e.target.value
+                    setMaxCommentsInput(value)
+                    const parsed = Number.parseInt(value, 10)
+                    if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 10000) {
+                      updateConfig({ max_comments_count: parsed })
+                    }
+                  }}
+                  onBlur={() => {
+                    const value = clampLimit(maxCommentsInput, config.max_comments_count)
+                    setMaxCommentsInput(String(value))
+                    updateConfig({ max_comments_count: value })
+                  }}
+                  disabled={isDisabled}
+                  className="h-9 text-xs"
+                />
+              </Field>
             </div>
-          ) : null}
-        </Section>
+          </Section>
+        </div>
 
         {/* Column 3: Output & Runtime Section */}
         <Section
@@ -388,7 +461,7 @@ export function CrawlerConfigPanel() {
         </Section>
       </div>
 
-      {/* Row 2: Start/Stop Button - Full Width */}
+      {/* Row 2: Primary Action - Full Width */}
       <div className="w-full">
         {isRunning ? (
           <Button

--- a/webui/src/components/console/Terminal.tsx
+++ b/webui/src/components/console/Terminal.tsx
@@ -6,6 +6,45 @@ import { useCrawlerStore } from '@/store/crawlerStore'
 import { Button } from '@/components/ui/button'
 import { DataExplorerDialog } from '@/components/data/DataExplorerDialog'
 
+const TERMINAL_BANNER_LINES = [
+  '   __  __          _ _       ____',
+  '  |  \\/  | ___  __| (_) __ _/ ___|_ __ __ ___      __',
+  "  | |\\/| |/ _ \\/ _` | |/ _` | |   | '__/ _` \\ \\ /\\ / /",
+  '  | |  | |  __/ (_| | | (_| | |___| | | (_| |\\ V  V /',
+  '  |_|  |_|\\___|\\__,_|_|\\__,_|\\____|_|  \\__,_| \\_/\\_/',
+  '',
+  '          [ NEURAL EXTRACTION UNIT v1.0 ]',
+]
+
+const TERMINAL_BANNER_WIDTH = Math.max(...TERMINAL_BANNER_LINES.map((line) => line.length))
+const TERMINAL_HORIZONTAL_FILL = '═'.repeat(128)
+
+function TerminalBanner() {
+  return (
+    <div className="ml-[2ch] inline-grid grid-cols-[auto_max-content_auto] text-cyber-neon-cyan/70 text-xs leading-tight">
+      <span>╔</span>
+      <span className="relative overflow-hidden">
+        <span className="absolute inset-0 whitespace-nowrap">{TERMINAL_HORIZONTAL_FILL}</span>
+      </span>
+      <span>╗</span>
+
+      {TERMINAL_BANNER_LINES.map((line, index) => (
+        <div key={`${index}-${line}`} className="contents">
+          <span>║</span>
+          <span className="whitespace-pre px-[1ch]">{line.padEnd(TERMINAL_BANNER_WIDTH)}</span>
+          <span>║</span>
+        </div>
+      ))}
+
+      <span>╚</span>
+      <span className="relative overflow-hidden">
+        <span className="absolute inset-0 whitespace-nowrap">{TERMINAL_HORIZONTAL_FILL}</span>
+      </span>
+      <span>╝</span>
+    </div>
+  )
+}
+
 export function Terminal() {
   const { t } = useTranslation('terminal')
   const [isCollapsed, setIsCollapsed] = useState(false)
@@ -105,17 +144,7 @@ export function Terminal() {
             {/* ASCII Art Banner when empty */}
             {logs.length === 0 ? (
               <div className="space-y-4">
-                <pre className="text-cyber-neon-cyan/70 text-xs leading-tight">
-{`  ╔══════════════════════════════════════════════════════╗
-  ║   __  __          _ _       ____                     ║
-  ║  |  \\/  | ___  __| (_) __ _/ ___|_ __ __ ___      __ ║
-  ║  | |\\/| |/ _ \\/ _\` | |/ _\` | |   | '__/ _\` \\ \\ /\\ / / ║
-  ║  | |  | |  __/ (_| | | (_| | |___| | | (_| |\\ V  V /  ║
-  ║  |_|  |_|\\___|\\__,_|_|\\__,_|\\____|_|  \\__,_| \\_/\\_/   ║
-  ║                                                      ║
-  ║          [ NEURAL EXTRACTION UNIT v1.0 ]             ║
-  ╚══════════════════════════════════════════════════════╝`}
-                </pre>
+                <TerminalBanner />
                 <div className="text-[#c9d1d9] text-xs space-y-1">
                   <p className="text-cyber-neon-green/70">{t('banner.systemInit')}</p>
                   <p className="text-[#8b949e]">{t('banner.configHint')}</p>

--- a/webui/src/components/layout/LanguageSwitch.tsx
+++ b/webui/src/components/layout/LanguageSwitch.tsx
@@ -20,7 +20,7 @@ export function LanguageSwitch() {
 
   return (
     <Select value={i18n.language} onValueChange={(lang) => i18n.changeLanguage(lang)}>
-      <SelectTrigger className="w-20 h-7 text-xs font-mono border-cyber-border-subtle bg-cyber-bg-tertiary/50 hover:border-cyber-neon-cyan/50 transition-colors">
+      <SelectTrigger className="w-24 h-7 text-xs font-mono border-cyber-border-subtle bg-cyber-bg-tertiary/50 hover:border-cyber-neon-cyan/50 transition-colors">
         <Globe className="w-3 h-3 mr-1 text-cyber-text-secondary" />
         <SelectValue>{currentLang.label}</SelectValue>
       </SelectTrigger>

--- a/webui/src/components/layout/Sidebar.tsx
+++ b/webui/src/components/layout/Sidebar.tsx
@@ -1,6 +1,8 @@
-import { Bug, Wifi, AlertTriangle, Github } from 'lucide-react'
+import { Bug, Wifi, AlertTriangle, Github, Save } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { useCrawlerStore } from '@/store/crawlerStore'
 import { useCrawlerStatus } from '@/hooks/useCrawler'
 import { LanguageSwitch } from './LanguageSwitch'
@@ -13,18 +15,29 @@ interface SidebarProps {
 export function Sidebar({ onShowDisclaimer }: SidebarProps) {
   const { t } = useTranslation()
   const { t: tLicense } = useTranslation('license')
+  const { t: tConfig } = useTranslation('config')
   const status = useCrawlerStore((state) => state.status)
+  const saveConfig = useCrawlerStore((state) => state.saveConfig)
 
   // Poll status
   useCrawlerStatus()
 
   const isRunning = status === 'running'
 
+  const handleSaveConfig = () => {
+    const saved = saveConfig()
+    if (saved) {
+      toast.success(tConfig('toast.configSaved'))
+    } else {
+      toast.error(tConfig('toast.configSaveFailed'))
+    }
+  }
+
   return (
     <header className="h-14 flex-shrink-0 glass-panel border-b border-cyber-border-subtle relative z-10">
-      <div className="h-full px-4 flex items-center justify-between">
+      <div className="grid h-full grid-cols-[1fr_auto_1fr] items-center gap-4 px-4">
         {/* Left: Logo and GitHub Star */}
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 items-center gap-3 justify-self-start">
           <Bug className="w-5 h-5 text-cyber-neon-cyan" />
           <span className="font-mono font-bold text-cyber-text-primary tracking-wider text-sm">
             MediaCrawler
@@ -51,7 +64,7 @@ export function Sidebar({ onShowDisclaimer }: SidebarProps) {
         {/* Center: Warning Text */}
         <button
           onClick={onShowDisclaimer}
-          className="flex items-center gap-3 px-4 py-1.5 rounded-lg border border-cyber-neon-orange/50 bg-cyber-neon-orange/10 hover:bg-cyber-neon-orange/20 transition-all cursor-pointer"
+          className="hidden 2xl:flex items-center gap-3 px-4 py-1.5 rounded-lg border border-cyber-neon-orange/50 bg-cyber-neon-orange/10 hover:bg-cyber-neon-orange/20 transition-all cursor-pointer"
         >
           <AlertTriangle className="w-4 h-4 text-cyber-neon-orange flex-shrink-0" />
           <div className="flex items-center gap-4 text-xs font-mono">
@@ -63,9 +76,28 @@ export function Sidebar({ onShowDisclaimer }: SidebarProps) {
             </span>
           </div>
         </button>
+        <button
+          type="button"
+          onClick={onShowDisclaimer}
+          className="2xl:hidden flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border border-cyber-neon-orange/50 bg-cyber-neon-orange/10 text-cyber-neon-orange transition-all hover:bg-cyber-neon-orange/20"
+          title={`${tLicense('content.line1')} ${tLicense('content.line2')}`}
+          aria-label={`${tLicense('content.line1')} ${tLicense('content.line2')}`}
+        >
+          <AlertTriangle className="h-4 w-4" />
+        </button>
 
         {/* Right: Actions and Status */}
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 justify-self-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleSaveConfig}
+            className="h-7 flex-shrink-0 border-cyber-neon-cyan/40 bg-cyber-neon-cyan/5 px-3 text-xs font-mono font-semibold text-cyber-neon-cyan hover:bg-cyber-neon-cyan/10 hover:text-cyber-neon-cyan hover:border-cyber-neon-cyan/70"
+          >
+            <Save className="w-3.5 h-3.5" />
+            {tConfig('button.saveAllConfig')}
+          </Button>
           {/* Theme Toggle */}
           <ThemeToggle />
           {/* Language Switch */}

--- a/webui/src/components/layout/ThemeToggle.tsx
+++ b/webui/src/components/layout/ThemeToggle.tsx
@@ -24,7 +24,7 @@ export function ThemeToggle() {
 
   return (
     <Select value={theme} onValueChange={(value: Theme) => setTheme(value)}>
-      <SelectTrigger className="w-20 h-7 text-xs font-mono border-cyber-border-subtle bg-cyber-bg-tertiary/50 hover:border-cyber-neon-cyan/50 transition-colors">
+      <SelectTrigger className="w-24 h-7 text-xs font-mono border-cyber-border-subtle bg-cyber-bg-tertiary/50 hover:border-cyber-neon-cyan/50 transition-colors">
         <Icon className="w-3 h-3 mr-1 text-cyber-text-secondary" />
         <SelectValue>{currentTheme.label}</SelectValue>
       </SelectTrigger>

--- a/webui/src/i18n/locales/en-US/config.json
+++ b/webui/src/i18n/locales/en-US/config.json
@@ -48,6 +48,10 @@
     },
     "loginMethod": "LOGIN_METHOD",
     "loginMethodPlaceholder": "Select login method",
+    "crawlConfig": "CRAWL_CONFIG",
+    "crawlConfigHint": "Post and comment limits",
+    "maxNotesCount": "POST LIMIT",
+    "maxCommentsCount": "COMMENTS PER POST",
     "cookies": "COOKIES",
     "cookiesHint": "Paste cookie string",
     "cookiesPlaceholder": "Paste cookies here...",
@@ -62,7 +66,12 @@
     "initiateScan": "INITIATE SCAN",
     "initiating": "INITIATING...",
     "terminate": "TERMINATE",
-    "stopping": "STOPPING..."
+    "stopping": "STOPPING...",
+    "saveAllConfig": "SAVE ALL CONFIG"
+  },
+  "toast": {
+    "configSaved": "Configuration saved",
+    "configSaveFailed": "Failed to save configuration"
   },
   "warning": {
     "cookieSlider": "[Note] Cookie login is not recommended for Xiaohongshu and Douyin due to slider captcha",

--- a/webui/src/i18n/locales/zh-CN/config.json
+++ b/webui/src/i18n/locales/zh-CN/config.json
@@ -48,6 +48,10 @@
     },
     "loginMethod": "登录方式",
     "loginMethodPlaceholder": "选择登录方式",
+    "crawlConfig": "抓取配置",
+    "crawlConfigHint": "帖子与评论数量上限",
+    "maxNotesCount": "帖子上限",
+    "maxCommentsCount": "单篇评论上限",
     "cookies": "Cookies",
     "cookiesHint": "粘贴 Cookie 字符串",
     "cookiesPlaceholder": "在此粘贴 Cookies...",
@@ -62,7 +66,12 @@
     "initiateScan": "开始爬虫",
     "initiating": "启动中...",
     "terminate": "终止",
-    "stopping": "停止中..."
+    "stopping": "停止中...",
+    "saveAllConfig": "保存全部配置"
+  },
+  "toast": {
+    "configSaved": "配置已保存",
+    "configSaveFailed": "配置保存失败"
   },
   "warning": {
     "cookieSlider": "[提示] 小红书和抖音平台不建议使用 Cookie 登录，因为可能会触发滑块验证",

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -20,6 +20,8 @@ export interface CrawlerConfig {
   save_option: string
   cookies: string
   headless: boolean
+  max_notes_count: number
+  max_comments_count: number
 }
 
 export interface CrawlerStatus {

--- a/webui/src/store/crawlerStore.ts
+++ b/webui/src/store/crawlerStore.ts
@@ -23,11 +23,15 @@ interface CrawlerState {
   clearLogs: () => void
   restoreLogs: () => void
   updateConfig: (config: Partial<CrawlerConfig>) => void
+  saveConfig: () => boolean
   reset: () => void
 }
 
 // 持久化相关的 localStorage key
 const CLEARED_LOG_ID_KEY = 'mediacrawler_cleared_log_id'
+const SAVED_CONFIG_KEY = 'mediacrawler_saved_config'
+const MIN_LIMIT = 1
+const MAX_LIMIT = 10000
 
 // 从 localStorage 读取清除标记
 function getClearedLogIdFromStorage(): number | null {
@@ -59,6 +63,48 @@ const defaultConfig: CrawlerConfig = {
   save_option: 'json',
   cookies: '',
   headless: false,
+  max_notes_count: 20,
+  max_comments_count: 10,
+}
+
+function clampInteger(value: unknown, fallback: number, max = MAX_LIMIT): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(max, Math.max(MIN_LIMIT, Math.trunc(value)))
+}
+
+function loadSavedConfig(): CrawlerConfig {
+  const restored: CrawlerConfig = { ...defaultConfig }
+  if (typeof window === 'undefined') return restored
+
+  try {
+    const raw = localStorage.getItem(SAVED_CONFIG_KEY)
+    if (!raw) return restored
+
+    const saved: unknown = JSON.parse(raw)
+    if (!saved || typeof saved !== 'object' || Array.isArray(saved)) return restored
+    const value = saved as Record<string, unknown>
+
+    if (typeof value.platform === 'string') restored.platform = value.platform
+    if (typeof value.login_type === 'string') restored.login_type = value.login_type
+    if (typeof value.crawler_type === 'string') restored.crawler_type = value.crawler_type
+    if (typeof value.keywords === 'string') restored.keywords = value.keywords
+    if (typeof value.specified_ids === 'string') restored.specified_ids = value.specified_ids
+    if (typeof value.creator_ids === 'string') restored.creator_ids = value.creator_ids
+    if (typeof value.save_option === 'string') restored.save_option = value.save_option
+    if (typeof value.enable_comments === 'boolean') restored.enable_comments = value.enable_comments
+    if (typeof value.enable_sub_comments === 'boolean') restored.enable_sub_comments = value.enable_sub_comments
+    if (typeof value.headless === 'boolean') restored.headless = value.headless
+
+    restored.start_page = clampInteger(value.start_page, defaultConfig.start_page)
+    restored.max_notes_count = clampInteger(value.max_notes_count, defaultConfig.max_notes_count)
+    restored.max_comments_count = clampInteger(value.max_comments_count, defaultConfig.max_comments_count)
+    restored.enable_sub_comments = restored.enable_comments && restored.enable_sub_comments
+    restored.cookies = ''
+  } catch {
+    return { ...defaultConfig }
+  }
+
+  return restored
 }
 
 export const useCrawlerStore = create<CrawlerState>((set, get) => ({
@@ -68,7 +114,7 @@ export const useCrawlerStore = create<CrawlerState>((set, get) => ({
   startedAt: null,
   logs: [],
   clearedAfterLogId: getClearedLogIdFromStorage(), // 从 localStorage 初始化
-  config: defaultConfig,
+  config: loadSavedConfig(),
 
   setStatus: (status) => {
     set({ status })
@@ -142,6 +188,18 @@ export const useCrawlerStore = create<CrawlerState>((set, get) => ({
     set((state) => ({
       config: { ...state.config, ...config },
     })),
+
+  saveConfig: () => {
+    if (typeof window === 'undefined') return false
+
+    try {
+      const { cookies: _cookies, ...safeConfig } = get().config
+      localStorage.setItem(SAVED_CONFIG_KEY, JSON.stringify(safeConfig))
+      return true
+    } catch {
+      return false
+    }
+  },
 
   reset: () =>
     set({

--- a/webui/src/types/crawler.ts
+++ b/webui/src/types/crawler.ts
@@ -11,6 +11,8 @@ export interface CrawlerConfig {
   save_option: string
   cookies: string
   headless: boolean
+  max_notes_count: number
+  max_comments_count: number
 }
 
 export interface CrawlerStatus {


### PR DESCRIPTION
## Summary

- expose post and per-post comment limits in the WebUI and pass them to crawler start requests
- add explicit persistence for the current safe WebUI configuration while excluding cookies
- split login and crawl settings into aligned cards and move the save action into the header
- prevent header control labels from being truncated and keep the original terminal banner frame closed

## Why

The WebUI previously restored default values after reopening and did not expose the crawler's post and comment limits. This made repeated local research runs require the same setup each time and forced limit changes to be made outside the UI.

## Behavior

- edits affect the current crawler configuration immediately
- clicking **Save all configuration** controls what is restored on the next page load
- unsaved edits do not overwrite the last saved configuration
- cookies are intentionally excluded from local persistence
- the default limits remain 20 posts and 10 comments per post

## Validation

- `npm run build`
- `git diff --check`
- browser QA for card alignment, input editing, save feedback, saved-value restoration, unsaved-value restoration, header labels, and terminal banner rendering

The WebUI package does not currently define an automated test script.
