### PR TITLE
fix(weibo): 修复 RFC2822 时间转换丢弃时区偏移导致时间戳晚 8 小时

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -47,3 +47,16 @@ async def test_convert_browser_context_cookies_uses_url_filter():
     browser_context.cookies.assert_awaited_once_with(urls=["https://www.douyin.com"])
     assert cookie_str == "sessionid=abc"
     assert cookie_dict == {"sessionid": "abc"}
+
+
+def test_rfc2822_to_timestamp_converts_utc_offset():
+    # 2023-12-23 17:12:54 +0800 == 2023-12-23 09:12:54 UTC == 1703322774
+    assert utils.rfc2822_to_timestamp("Sat Dec 23 17:12:54 +0800 2023") == 1703322774
+
+
+def test_rfc2822_to_timestamp_agrees_with_china_datetime():
+    rfc2822_time = "Sat Dec 23 17:12:54 +0800 2023"
+
+    assert utils.rfc2822_to_timestamp(rfc2822_time) == int(
+        utils.rfc2822_to_china_datetime(rfc2822_time).timestamp()
+    )

--- a/tools/time_util.py
+++ b/tools/time_util.py
@@ -118,7 +118,7 @@ def rfc2822_to_timestamp(rfc2822_time):
     dt_object = datetime.strptime(rfc2822_time, rfc2822_format)
 
     # Convert datetime object to UTC time
-    dt_utc = dt_object.replace(tzinfo=timezone.utc)
+    dt_utc = dt_object.astimezone(timezone.utc)
 
     # Calculate Unix timestamp from UTC time
     timestamp = int(dt_utc.timestamp())


### PR DESCRIPTION
## 问题

`tools/time_util.py` 的 `rfc2822_to_timestamp()` 用 `datetime.replace(tzinfo=timezone.utc)` 去处理一个**已经带时区偏移**的 datetime:

```python
dt_object = datetime.strptime(rfc2822_time, "%a %b %d %H:%M:%S %z %Y")  # %z 已解析出 +0800
dt_utc = dt_object.replace(tzinfo=timezone.utc)                         # 覆盖 tzinfo,不做换算
```

`replace(tzinfo=...)` 只替换 tzinfo 字段、不调整时间数值,于是 `+0800` 的时间被当成 UTC,算出的时间戳比真实时间晚 8 小时。

复现(示例值取自该文件末尾 `__main__` 里的那一个):

```python
>>> from tools.time_util import rfc2822_to_timestamp, rfc2822_to_china_datetime
>>> s = "Sat Dec 23 17:12:54 +0800 2023"
>>> rfc2822_to_timestamp(s)
1703351574                                  # => 2023-12-24 01:12:54 +0800
>>> int(rfc2822_to_china_datetime(s).timestamp())
1703322774                                  # => 2023-12-23 17:12:54 +0800  (正确)
```

## 影响

微博的 `created_at` 正是 RFC2822 格式,`store/weibo/__init__.py` 有两处调用:

- `L93` — 帖子的 `create_time`
- `L146` — 评论的 `create_time`

因此落库的每条微博帖子和评论的 `create_time` 都晚 8 小时。更直接的表现是**同一条记录里两个相邻字段互相矛盾**:`create_date_time` 走 `rfc2822_to_china_datetime()`(内部用 `astimezone`,结果正确),`create_time` 走本函数,两者恒差 28800 秒。跨日内容若按 `create_time` 归日期,还会整体偏移一天。

## 改动

把 `replace(tzinfo=timezone.utc)` 改为 `astimezone(timezone.utc)`,即真正做时区换算,与紧邻上方的 `rfc2822_to_china_datetime()` 保持一致的处理方式。原有注释 `# Convert datetime object to UTC time` 在修复后才名副其实。

顺带在 `test/test_utils.py` 补两条离线单测(不需要网络、cookie 或登录态):

- `test_rfc2822_to_timestamp_converts_utc_offset` — 断言 `+0800` 输入对应的时间戳
- `test_rfc2822_to_timestamp_agrees_with_china_datetime` — 断言 `create_time` 与 `create_date_time` 指向同一时刻,把这次的一致性不变量锁住

两条测试在修复前均失败(差 28800 秒),修复后通过。另外在 `TZ=UTC / Asia/Shanghai / America/New_York / Europe/London` 下各跑一遍结果一致,不依赖运行机器的本地时区。

`tests/test_weibo_no_user_info.py` 中的 `RFC2822_TIME` 仅作为输入、未断言具体时间戳,不受本次改动影响。
