### PR TITLE
fix(cache): clear expired entries safely

### DIFF
--- a/cache/local_cache.py
+++ b/cache/local_cache.py
@@ -114,9 +114,13 @@ class ExpiringLocalCache(AbstractCache):
         Clean up cache based on expiration time
         :return:
         """
-        for key, (value, expire_time) in self._cache_container.items():
-            if expire_time < time.time():
-                del self._cache_container[key]
+        expired_keys = [
+            key
+            for key, (_, expire_time) in self._cache_container.items()
+            if expire_time < time.time()
+        ]
+        for key in expired_keys:
+            del self._cache_container[key]
 
     async def _start_clear_cron(self):
         """

--- a/test/test_expiring_local_cache.py
+++ b/test/test_expiring_local_cache.py
@@ -51,6 +51,14 @@ class TestExpiringLocalCache(unittest.TestCase):
         time.sleep(12)
         self.assertIsNone(self.cache.get('key'))
 
+    def test_clear_removes_multiple_expired_keys(self):
+        self.cache.set('first', 'value', 0)
+        self.cache.set('second', 'value', 0)
+
+        self.cache._clear()
+
+        self.assertEqual(self.cache.keys('*'), [])
+
     def tearDown(self):
         del self.cache
 


### PR DESCRIPTION
### Summary
- snapshot expired cache keys before deleting them
- avoid mutating the cache dictionary while iterating over it
- add regression coverage for multiple entries expiring in one cleanup pass

### Verification
- `pytest -q test/test_expiring_local_cache.py --disable-warnings`
- 4 passed
- `python3 -m py_compile cache/local_cache.py test/test_expiring_local_cache.py`

The repository preflight currently reports `NOASSERTION` for the upstream license; this PR changes only the existing cache implementation and tests.