### PR TITLE
fix(cookies): preserve values containing equals

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -34,6 +34,12 @@ def test_convert_cookies():
     assert cookie_dict.get("a1") == "x000101360"
 
 
+def test_convert_str_cookie_to_dict_preserves_equals_in_cookie_values():
+    cookie_dict = utils.convert_str_cookie_to_dict("session=eyJhbGciOiJIUzI1NiJ9==; theme=dark")
+
+    assert cookie_dict == {"session": "eyJhbGciOiJIUzI1NiJ9==", "theme": "dark"}
+
+
 @pytest.mark.asyncio
 async def test_convert_browser_context_cookies_uses_url_filter():
     browser_context = AsyncMock()

--- a/tools/crawler_util.py
+++ b/tools/crawler_util.py
@@ -164,7 +164,7 @@ def convert_str_cookie_to_dict(cookie_str: str) -> Dict:
         cookie = cookie.strip()
         if not cookie:
             continue
-        cookie_list = cookie.split("=")
+        cookie_list = cookie.split("=", 1)
         if len(cookie_list) != 2:
             continue
         cookie_value = cookie_list[1]


### PR DESCRIPTION
### Summary
- split cookie pairs at the first `=` only
- preserve base64/JWT-style cookie values with padding characters
- add regression coverage alongside the existing cookie utility tests

### Verification
- `uv run --no-project --with pytest --with pytest-asyncio --with httpx --with playwright --with pillow --with opencv-python-headless --with numpy pytest -q test/test_utils.py --disable-warnings`
- 5 passed
- `python3 -m py_compile tools/crawler_util.py test/test_utils.py`

The repository preflight currently reports `NOASSERTION` for the upstream license; this PR is limited to the existing parser and tests.