### PR TITLE
fix: avoid mutable default in ContextVar and safely retrieve tasks

### DIFF
--- a/media_platform/kuaishou/core.py
+++ b/media_platform/kuaishou/core.py
@@ -314,7 +314,7 @@ class KuaishouCrawler(AbstractCrawler):
                 )
                 # use time.sleeep block main coroutine instead of asyncio.sleep and cacel running comment task
                 # maybe kuaishou block our request, we will take a nap and update the cookie again
-                current_running_tasks = comment_tasks_var.get()
+                current_running_tasks = comment_tasks_var.get() or []
                 for task in current_running_tasks:
                     task.cancel()
                 time.sleep(20)

--- a/tools/time_util.py
+++ b/tools/time_util.py
@@ -89,9 +89,8 @@ def get_unix_time_from_time_str(time_str):
         format_str = "%Y-%m-%d %H:%M:%S"
         tm_object = time.strptime(str(time_str), format_str)
         return int(time.mktime(tm_object))
-    except Exception as e:
+    except Exception:
         return 0
-    pass
 
 
 def get_unix_timestamp():

--- a/var.py
+++ b/var.py
@@ -20,12 +20,11 @@
 
 from asyncio.tasks import Task
 from contextvars import ContextVar
-from typing import List
 
 import aiomysql
 
 request_keyword_var: ContextVar[str] = ContextVar("request_keyword", default="")
 crawler_type_var: ContextVar[str] = ContextVar("crawler_type", default="")
-comment_tasks_var: ContextVar[List[Task]] = ContextVar("comment_tasks", default=[])
+comment_tasks_var: ContextVar[list[Task] | None] = ContextVar("comment_tasks", default=None)
 db_conn_pool_var: ContextVar[aiomysql.Pool] = ContextVar("db_conn_pool_var")
 source_keyword_var: ContextVar[str] = ContextVar("source_keyword", default="")


### PR DESCRIPTION
### 变更说明
1. **避免 ContextVar 使用可变对象作为默认值**：将 `var.py` 中的 `comment_tasks_var` 默认值从可变列表 `default=[]` 改为 `default=None`，避免在多个异步上下文之间意外共享和修改同一列表实例。
2. **安全获取任务列表**：在 `media_platform/kuaishou/core.py` 中使用 `comment_tasks_var.get() or []` 安全提取当前运行任务。
3. **代码清理**：清理 `tools/time_util.py` 中未使用的异常捕获变量和多余的 `pass` 语句。