### PR TITLE
fix(cache): keep expiration cleanup running

### DIFF
--- a/cache/local_cache.py
+++ b/cache/local_cache.py
@@ -64,7 +64,7 @@ class ExpiringLocalCache(AbstractCache):
             return None
 
         # If the key has expired, delete it and return None
-        if expire_time < time.time():
+        if expire_time <= time.time():
             del self._cache_container[key]
             return None
 
@@ -86,6 +86,7 @@ class ExpiringLocalCache(AbstractCache):
         :param pattern: Matching pattern
         :return:
         """
+        self._clear()
         if pattern == '*':
             return list(self._cache_container.keys())
 
@@ -114,9 +115,13 @@ class ExpiringLocalCache(AbstractCache):
         Clean up cache based on expiration time
         :return:
         """
-        for key, (value, expire_time) in self._cache_container.items():
-            if expire_time < time.time():
-                del self._cache_container[key]
+        now = time.time()
+        expired_keys = [
+            key for key, (_, deadline) in self._cache_container.items()
+            if deadline <= now
+        ]
+        for key in expired_keys:
+            self._cache_container.pop(key, None)
 
     async def _start_clear_cron(self):
         """

--- a/tests/test_local_cache_expiry.py
+++ b/tests/test_local_cache_expiry.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Repository: https://github.com/NanmiCoder/MediaCrawler/blob/main/tests/test_local_cache_expiry.py
+# GitHub: https://github.com/NanmiCoder
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+# 声明：本代码仅供学习和研究目的使用。使用者应遵守以下原则：
+# 1. 不得用于任何商业用途。
+# 2. 使用时应遵守目标平台的使用条款和robots.txt规则。
+# 3. 不得进行大规模爬取或对平台造成运营干扰。
+# 4. 应合理控制请求频率，避免给目标平台带来不必要的负担。
+# 5. 不得用于任何非法或不当的用途。
+#
+# 详细许可条款请参阅项目根目录下的LICENSE文件。
+# 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
+
+import asyncio
+
+import pytest
+
+from cache.local_cache import ExpiringLocalCache
+
+
+@pytest.mark.asyncio
+async def test_local_cleanup_removes_all_expired_entries_and_keeps_running(monkeypatch):
+    now = 100.0
+    monkeypatch.setattr("cache.local_cache.time.time", lambda: now)
+    cache = ExpiringLocalCache(cron_interval=0.001)
+    try:
+        cache.set("first", "one", 1)
+        cache.set("second", "two", 1)
+        cache.set("live", "three", 20)
+        now = 102.0
+        await asyncio.sleep(0.02)
+        assert not cache._cron_task.done()
+        assert cache.keys("*") == ["live"]
+        assert cache.get("live") == "three"
+    finally:
+        cache._cron_task.cancel()
+        await asyncio.gather(cache._cron_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reader", ["get", "keys"])
+async def test_expiry_boundary_is_consistent_for_get_and_keys(monkeypatch, reader):
+    now = 100.0
+    monkeypatch.setattr("cache.local_cache.time.time", lambda: now)
+    cache = ExpiringLocalCache()
+    try:
+        cache.set("item", "value", 1)
+        now = 101.0
+        if reader == "get":
+            assert cache.get("item") is None
+        else:
+            assert cache.keys("*") == []
+    finally:
+        cache._cron_task.cancel()
+        await asyncio.gather(cache._cron_task, return_exceptions=True)


### PR DESCRIPTION
ExpiringLocalCache deletes dictionary entries while iterating over them. The first expired entry raises RuntimeError and terminates the background cleanup task. Collecting expired keys before deletion keeps the task alive and removes every expired item; get and keys now agree that a value is expired at its deadline.

This PR only addresses expiration cleanup. It introduces no dependency or cache format change.

Validation: all 3 regression cases fail on the original implementation. The isolated branch based on upstream main d6f7c5b passes the complete tests/ suite (99 tests, Python 3.11, Windows with PYTHONUTF8=1). Tests cover task survival, multiple expired entries, live entries, and get/keys at the exact deadline. No external service is involved. The same fix passes the four Quality checks in [fork PR #17](https://github.com/saksim/MediaCrawler/pull/17).

Related report: saksim/MediaCrawler#10.