### PR TITLE
fix(database): preserve reserved characters in connection credentials

### DIFF
--- a/database/db_session.py
+++ b/database/db_session.py
@@ -17,6 +17,7 @@
 # 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
 
 from sqlalchemy import text
+from sqlalchemy.engine import URL
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from contextlib import asynccontextmanager
@@ -28,17 +29,29 @@ from config.db_config import mysql_db_config, sqlite_db_config, postgres_db_conf
 _engines = {}
 
 
+def _database_url(driver: str, settings: dict, database: str | None = None) -> URL:
+    """Pass credentials as fields so reserved URL characters stay literal."""
+    return URL.create(
+        drivername=driver,
+        username=settings["user"],
+        password=settings["password"],
+        host=settings["host"],
+        port=int(settings["port"]),
+        database=database,
+    )
+
+
 async def create_database_if_not_exists(db_type: str):
     if db_type == "mysql" or db_type == "db":
         # Connect to the server without a database
-        server_url = f"mysql+asyncmy://{mysql_db_config['user']}:{mysql_db_config['password']}@{mysql_db_config['host']}:{mysql_db_config['port']}"
+        server_url = _database_url("mysql+asyncmy", mysql_db_config)
         engine = create_async_engine(server_url, echo=False)
         async with engine.connect() as conn:
             await conn.execute(text(f"CREATE DATABASE IF NOT EXISTS {mysql_db_config['db_name']}"))
         await engine.dispose()
     elif db_type == "postgres":
         # Connect to the default 'postgres' database
-        server_url = f"postgresql+asyncpg://{postgres_db_config['user']}:{postgres_db_config['password']}@{postgres_db_config['host']}:{postgres_db_config['port']}/postgres"
+        server_url = _database_url("postgresql+asyncpg", postgres_db_config, "postgres")
         print(f"[init_db] Connecting to Postgres: host={postgres_db_config['host']}, port={postgres_db_config['port']}, user={postgres_db_config['user']}, dbname=postgres")
         # Isolation level AUTOCOMMIT is required for CREATE DATABASE
         engine = create_async_engine(server_url, echo=False, isolation_level="AUTOCOMMIT")
@@ -61,11 +74,11 @@ def get_async_engine(db_type: str = None):
         return None
 
     if db_type == "sqlite":
-        db_url = f"sqlite+aiosqlite:///{sqlite_db_config['db_path']}"
+        db_url = URL.create("sqlite+aiosqlite", database=sqlite_db_config["db_path"])
     elif db_type == "mysql" or db_type == "db":
-        db_url = f"mysql+asyncmy://{mysql_db_config['user']}:{mysql_db_config['password']}@{mysql_db_config['host']}:{mysql_db_config['port']}/{mysql_db_config['db_name']}"
+        db_url = _database_url("mysql+asyncmy", mysql_db_config, mysql_db_config["db_name"])
     elif db_type == "postgres":
-        db_url = f"postgresql+asyncpg://{postgres_db_config['user']}:{postgres_db_config['password']}@{postgres_db_config['host']}:{postgres_db_config['port']}/{postgres_db_config['db_name']}"
+        db_url = _database_url("postgresql+asyncpg", postgres_db_config, postgres_db_config["db_name"])
     else:
         raise ValueError(f"Unsupported database type: {db_type}")
 

--- a/docs/database-urls.md
+++ b/docs/database-urls.md
@@ -1,0 +1,5 @@
+# 数据库连接中的特殊字符
+
+MySQL/PostgreSQL 的初始化连接与正式连接均使用 SQLAlchemy `URL.create()`。
+用户名和密码可以直接包含 URL 保留字符，无需用户手工百分号编码。
+SQLite 的路径也使用结构化 URL 传入。

--- a/tests/test_database_urls.py
+++ b/tests/test_database_urls.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025 relakkes@gmail.com
+#
+# This file is part of MediaCrawler project.
+# Repository: https://github.com/NanmiCoder/MediaCrawler/blob/main/tests/test_database_urls.py
+# GitHub: https://github.com/NanmiCoder
+# Licensed under NON-COMMERCIAL LEARNING LICENSE 1.1
+#
+# 声明：本代码仅供学习和研究目的使用。使用者应遵守以下原则：
+# 1. 不得用于任何商业用途。
+# 2. 使用时应遵守目标平台的使用条款和robots.txt规则。
+# 3. 不得进行大规模爬取或对平台造成运营干扰。
+# 4. 应合理控制请求频率，避免给目标平台带来不必要的负担。
+# 5. 不得用于任何非法或不当的用途。
+#
+# 详细许可条款请参阅项目根目录下的LICENSE文件。
+# 使用本代码即表示您同意遵守上述原则和LICENSE中的所有条款。
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from sqlalchemy.engine import make_url
+
+from database import db_session
+
+
+@pytest.mark.parametrize("db_type,settings", [
+    ("db", db_session.mysql_db_config),
+    ("postgres", db_session.postgres_db_config),
+])
+def test_database_credentials_are_not_parsed_as_url_delimiters(monkeypatch, db_type, settings):
+    monkeypatch.setitem(settings, "user", "crawler@team")
+    monkeypatch.setitem(settings, "password", "p@ss/word:#?%")
+    monkeypatch.setattr(db_session, "_engines", {})
+    factory = Mock()
+    monkeypatch.setattr(db_session, "create_async_engine", factory)
+    db_session.get_async_engine(db_type)
+    url = make_url(factory.call_args.args[0])
+    assert url.username == settings["user"]
+    assert url.password == settings["password"]
+    assert url.host == settings["host"]
+    assert url.database == settings["db_name"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("db_type,settings,database", [
+    ("db", db_session.mysql_db_config, None),
+    ("postgres", db_session.postgres_db_config, "postgres"),
+])
+async def test_database_initialization_preserves_credentials(monkeypatch, db_type, settings, database):
+    monkeypatch.setitem(settings, "user", "crawler@team")
+    monkeypatch.setitem(settings, "password", "p@ss/word:#?%")
+    connection = Mock(execute=AsyncMock(return_value=Mock(scalar=Mock(return_value=1))))
+
+    @asynccontextmanager
+    async def connect():
+        yield connection
+
+    engine = Mock(connect=connect, dispose=AsyncMock())
+    factory = Mock(return_value=engine)
+    monkeypatch.setattr(db_session, "create_async_engine", factory)
+    await db_session.create_database_if_not_exists(db_type)
+    url = make_url(factory.call_args.args[0])
+    assert url.username == settings["user"]
+    assert url.password == settings["password"]
+    assert url.host == settings["host"]
+    assert url.database == database
+    engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_url_and_write_work_with_reserved_path_characters(tmp_path, monkeypatch):
+    from sqlalchemy import text
+    monkeypatch.setitem(db_session.sqlite_db_config, "db_path", str(tmp_path / "data #1.db"))
+    monkeypatch.setattr(db_session, "_engines", {})
+    engine = db_session.get_async_engine("sqlite")
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(text("CREATE TABLE notes (id INTEGER PRIMARY KEY)"))
+            await connection.execute(text("INSERT INTO notes VALUES (1)"))
+            result = await connection.execute(text("SELECT id FROM notes"))
+            assert result.scalar_one() == 1
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
Building database URLs with f-strings parses reserved characters in usernames/passwords as URL delimiters. For example, p@ss/word:#?% is read as password p. This breaks both initialization and normal connections.

Use SQLAlchemy URL.create to pass connection fields directly for MySQL/PostgreSQL initialization and regular engines, and the SQLite database path. Drivers, database schemas, and dependencies are unchanged. Credentials should be supplied literally, without manual percent encoding.

Validation: 4 new MySQL/PostgreSQL credential tests fail before the fix; the SQLite compatibility test passes. The isolated upstream branch passes all 101 tests (Python 3.11, Windows with PYTHONUTF8=1). Initialization and normal connections are tested through mocked engines; a temporary SQLite database executes create/insert/select. No live MySQL/PostgreSQL service is used.

Only this connection URL issue is included. Fork tracking and CI: [PR #18](https://github.com/saksim/MediaCrawler/pull/18). Related report: saksim/MediaCrawler#8.